### PR TITLE
Pre-generator, world borders, cartographer, GUI pt2, bugfixes

### DIFF
--- a/common/src/main/java/com/khorn/terraincontrol/configuration/PluginConfig.java
+++ b/common/src/main/java/com/khorn/terraincontrol/configuration/PluginConfig.java
@@ -79,6 +79,9 @@ public final class PluginConfig extends ConfigFile
         this.LogLevel = reader.getSetting(PluginStandardValues.LogLevel);
         this.biomeConfigExtension = reader.getSetting(BiomeStandardValues.BIOME_CONFIG_EXTENSION);
         this.SpawnLog = reader.getSetting(PluginStandardValues.SPAWN_LOG);
+        this.Cartographer = reader.getSetting(PluginStandardValues.CARTOGRAPHER);
+        this.CartographerHeightOffset = reader.getSetting(PluginStandardValues.CARTOGRAPHER_HEIGHT_OFFSET);
+        this.PregeneratorMaxChunksPerTick = reader.getSetting(PluginStandardValues.PREGENERATOR_MAX_CHUNKS_PER_TICK);
     }
 
     @Override
@@ -124,7 +127,19 @@ public final class PluginConfig extends ConfigFile
         
         writer.putSetting(PluginStandardValues.SPAWN_LOG, this.SpawnLog,
 		        "Shows detailed information about mob and BO3 spawning that is useful for TC world devs.",
-		        "Defaults to: false"); 
+		        "Defaults to: false");
+
+        writer.putSetting(PluginStandardValues.PREGENERATOR_MAX_CHUNKS_PER_TICK, this.PregeneratorMaxChunksPerTick,
+		        "The number of chunks the pre-generator is allowed to generate for each server tick.",
+		        "Higher numbers make pre-generation faster but increase memory usage and will cause lag.");
+        
+        writer.putSetting(PluginStandardValues.CARTOGRAPHER, this.Cartographer,
+        		 "Currently in development, the Cartographer is a miniature version of the world (1/16th scale)",
+        		 "that spawns at the spawn point and grows larger each time a chunk in the world is generated.",
+        		 "handy for TC map makers when combined with the pre-generator to get a quick overview of a world.");
+        
+        writer.putSetting(PluginStandardValues.CARTOGRAPHER_HEIGHT_OFFSET,this. CartographerHeightOffset,
+        		"The Cartographer spawns at the height of the spawn point + the CartographerHeightOffset.");
     }
 
     public LogLevels getLogLevel()
@@ -136,4 +151,21 @@ public final class PluginConfig extends ConfigFile
 	 * Shows detailed information about mob and BO3 spawning that is useful for TC world devs.
 	 */
 	public boolean SpawnLog = false;    
+	
+	/**
+	 * Forge only: Spawns the Cartographer world map above the spawn point
+	 */
+	public boolean Cartographer = false;
+	
+	/**
+	 * Forge only: The Cartographer map is spawned at the highest block at the spawn point + CartographerHeightOffset
+	 */
+	public int CartographerHeightOffset = 50;
+
+	/**
+	 * Forge only: This is the number of chunks the pre-generator generates each server tick.
+	 * Higher values make pre-generation faster but can cause lag and increased memory usage.
+	 */
+	public int PregeneratorMaxChunksPerTick = 1;
+	
 }

--- a/common/src/main/java/com/khorn/terraincontrol/configuration/ServerConfigProvider.java
+++ b/common/src/main/java/com/khorn/terraincontrol/configuration/ServerConfigProvider.java
@@ -125,6 +125,12 @@ public final class ServerConfigProvider implements ConfigProvider
 
         return settingsMap;
     }
+    
+    public void saveWorldConfig()
+    {
+    	File worldConfigFile = new File(settingsDir, WorldStandardValues.WORLD_CONFIG_FILE_NAME);
+    	FileSettingsWriter.writeToFile(worldConfig.getSettingsAsMap(), worldConfigFile, worldConfig.SettingsMode);
+    }
 
     private void loadBiomes(SettingsMap worldConfigSettings)
     {

--- a/common/src/main/java/com/khorn/terraincontrol/configuration/WorldConfig.java
+++ b/common/src/main/java/com/khorn/terraincontrol/configuration/WorldConfig.java
@@ -185,7 +185,6 @@ public class WorldConfig extends ConfigFile
     public String author;
     public String description;
 
-	public boolean PreGenerationSafeMode;
 	public int PreGenerationRadius;
 	public int WorldBorderRadius;
     public String worldSeed;
@@ -212,29 +211,32 @@ public class WorldConfig extends ConfigFile
         this.readConfigSettings(settingsReader);
         // Clamp Settings to acceptable values
         this.correctSettings();
-        
-        // Check biome ids, These are the names from the worldConfig file
-        // Corrects any instances of incorrect biome id.
-        for (Iterator<Entry<String, Integer>> it = customBiomeGenerationIds.entrySet().iterator(); it.hasNext();)
-        {
-            Entry<String, Integer> entry = it.next();
-
-            // Check name
-            String biomeName = entry.getKey();
-            if (DefaultBiome.Contain(biomeName))
-            {
-                TerrainControl.log(LogMarker.WARN, "CustomBiomes only accepts custom biomes,"
-                        + " {} is a vanilla biome. Removing it from the list.", biomeName);
-                it.remove();
-                continue;
-            }
-
-            // Check id
-            int biomeId = entry.getValue();
-            if (biomeId == -1)
-            {
-                entry.setValue(world.getFreeBiomeId());
-            }
+                
+        if(world != null) // If world is null then this method was called from WorldCreationMenu and only needs pre-generator and worldborder settings. TODO: Make this prettier?
+        {        
+	        // Check biome ids, These are the names from the worldConfig file
+	        // Corrects any instances of incorrect biome id.
+	        for (Iterator<Entry<String, Integer>> it = customBiomeGenerationIds.entrySet().iterator(); it.hasNext();)
+	        {
+	            Entry<String, Integer> entry = it.next();
+	
+	            // Check name
+	            String biomeName = entry.getKey();
+	            if (DefaultBiome.Contain(biomeName))
+	            {
+	                TerrainControl.log(LogMarker.WARN, "CustomBiomes only accepts custom biomes,"
+	                        + " {} is a vanilla biome. Removing it from the list.", biomeName);
+	                it.remove();
+	                continue;
+	            }
+	
+	            // Check id
+	            int biomeId = entry.getValue();
+	            if (biomeId == -1)
+	            {
+	                entry.setValue(world.getFreeBiomeId());
+	            }
+	        }
         }
     }
 
@@ -495,7 +497,6 @@ public class WorldConfig extends ConfigFile
         this.description = reader.getSetting(WorldStandardValues.DESCRIPTION);
         
         this.PreGenerationRadius = reader.getSetting(WorldStandardValues.PREGENERATION_RADIUS);
-        this.PreGenerationSafeMode = reader.getSetting(WorldStandardValues.PREGENERATION_SAFE_MODE);
         this.WorldBorderRadius = reader.getSetting(WorldStandardValues.WORLD_BORDER_RADIUS);
         
         this.worldSeed = reader.getSetting(WorldStandardValues.WORLD_SEED);
@@ -1011,34 +1012,18 @@ public class WorldConfig extends ConfigFile
         writer.putSetting(WorldStandardValues.MIN_TEMPERATURE, this.minTemperature);
         writer.putSetting(WorldStandardValues.MAX_TEMPERATURE, this.maxTemperature);
         
-        
-        
-                
-        
-        
         writer.bigTitle("World Seed");        
         writer.putSetting(WorldStandardValues.WORLD_SEED, this.worldSeed,
 	        "The seed that will be used for this world unless it is overriden in the world creation menu.",
 	        "Leave blank for a random seed."
     	);
         
-        writer.bigTitle("Pre-generation safe mode");
-        writer.putSetting(WorldStandardValues.PREGENERATION_SAFE_MODE, this.PreGenerationSafeMode,
-            "Disabling safe mode can greatly increase pre-generation speed",
-    		"but increases memory usage and may require server reboots during",
-    		"pre-generation. This is recommended only for installations with",
-    		"more than 2GB memory. Pre-generation will automatically resume",
-    		"when entering the world after a server reboot.",               
-    		"Defaults to: true",
-    		"This property is used only by the Minecraft Worlds mod"
-		);
-        
         writer.bigTitle("Pre-generation radius");        
         writer.putSetting(WorldStandardValues.PREGENERATION_RADIUS, this.PreGenerationRadius,
 	        "This is the radius in chunks around the spawn chunk within which chunks will automatically be spawned (uses a rectangle, not a circle around the spawn location!",
 			"Defaults to: 0 (disabled)",
 			"This property is used only by the Minecraft Worlds mod"        		
-		);  
+		);
         
         writer.bigTitle("World border radius");        
         writer.putSetting(WorldStandardValues.WORLD_BORDER_RADIUS, this.WorldBorderRadius,

--- a/common/src/main/java/com/khorn/terraincontrol/configuration/standard/PluginStandardValues.java
+++ b/common/src/main/java/com/khorn/terraincontrol/configuration/standard/PluginStandardValues.java
@@ -26,10 +26,12 @@ public class PluginStandardValues extends Settings
      * Name of the plugin, "TerrainControl".
      */
     public static final String PLUGIN_NAME = "TerrainControl";
-    
-    
-    /**
-     * Shows detailed information about mob and BO3 spawning that is useful for TC world devs.
-     */
+        
     public static final Setting<Boolean> SPAWN_LOG = booleanSetting("SpawnLog", false);
+    
+    public static final Setting<Boolean> CARTOGRAPHER = booleanSetting("Cartographer", false);
+    
+    public static final Setting<Integer> CARTOGRAPHER_HEIGHT_OFFSET = intSetting("CartographerHeightOffset", 100, -255, 255);
+    
+    public static final Setting<Integer> PREGENERATOR_MAX_CHUNKS_PER_TICK = intSetting("PregeneratorMaxChunksPerTick", 1, 1, Integer.MAX_VALUE);   
 }

--- a/common/src/main/java/com/khorn/terraincontrol/configuration/standard/WorldStandardValues.java
+++ b/common/src/main/java/com/khorn/terraincontrol/configuration/standard/WorldStandardValues.java
@@ -117,8 +117,7 @@ public class WorldStandardValues extends Settings
             MINESHAFTS_ENABLED = booleanSetting("MineshaftsEnabled", true),
             RARE_BUILDINGS_ENABLED = booleanSetting("RareBuildingsEnabled", true),
             OCEAN_MONUMENTS_ENABLED = booleanSetting("OceanMonumentsEnabled", true),
-            POPULATE_USING_SAVED_BIOMES = booleanSetting("PopulateUsingSavedBiomes", false),
-    		PREGENERATION_SAFE_MODE = booleanSetting("PreGenerationSafeMode", true);
+            POPULATE_USING_SAVED_BIOMES = booleanSetting("PopulateUsingSavedBiomes", false);
 
     public static final Setting<LocalMaterialData>
             WATER_BLOCK = new MaterialSetting("WaterBlock", DefaultMaterial.STATIONARY_WATER),

--- a/common/src/main/java/com/khorn/terraincontrol/customobjects/bo3/BO3Config.java
+++ b/common/src/main/java/com/khorn/terraincontrol/customobjects/bo3/BO3Config.java
@@ -295,6 +295,7 @@ public class BO3Config extends ConfigFile
         
         // EntityFunctions
         writer.bigTitle("EntityFunctions",
+        		"Forge only (this may have changed, check for updates).",
                 "An EntityFunction spawns an entity instead of a block. The entity is spawned only once when the BO3 is spawned.",
                 "Entities are persistent by default so they don't de-spawn when no player is near, they are only unloaded.",
                 "Usage: Entity(x,y,z,mobName,groupSize,NameTagOrNBTFileName) or Entity(x,y,z,mobName,groupSize)",		
@@ -304,7 +305,7 @@ public class BO3Config extends ConfigFile
                 "entity and give it custom attributes etc. You can copy the DATA part of a summon command including surrounding ",
                 "curly braces to a .txt file, for instance for: \"/summon Skeleton x y z {DATA}\"");
         
-        writer.addConfigFunctions(Arrays.asList(branches[0]));
+        writer.addConfigFunctions(Arrays.asList(entityFunctions[0]));
     }
 
     @Override

--- a/common/src/main/java/com/khorn/terraincontrol/generator/ObjectSpawner.java
+++ b/common/src/main/java/com/khorn/terraincontrol/generator/ObjectSpawner.java
@@ -8,10 +8,13 @@ import com.khorn.terraincontrol.configuration.ConfigFunction;
 import com.khorn.terraincontrol.configuration.ConfigProvider;
 import com.khorn.terraincontrol.configuration.WorldConfig;
 import com.khorn.terraincontrol.generator.noise.NoiseGeneratorNewOctaves;
+import com.khorn.terraincontrol.generator.resource.CustomStructureGen;
 import com.khorn.terraincontrol.generator.resource.Resource;
 import com.khorn.terraincontrol.logging.LogMarker;
 import com.khorn.terraincontrol.util.ChunkCoordinate;
+import com.khorn.terraincontrol.util.minecraftTypes.DefaultMaterial;
 
+import java.util.Arrays;
 import java.util.Random;
 
 public class ObjectSpawner
@@ -29,59 +32,71 @@ public class ObjectSpawner
         new NoiseGeneratorNewOctaves(new Random(world.getSeed()), 4);
     }
 
+    public boolean processing = false;   
     public void populate(ChunkCoordinate chunkCoord)
-    {
-        // Get the corner block coords
-        int x = chunkCoord.getChunkX() * 16;
-        int z = chunkCoord.getChunkZ() * 16;
-
-        // Get the biome of the other corner
-        LocalBiome biome = world.getBiome(x + 15, z + 15);
-
-        // Null check
-        if (biome == null)
-        {
-            TerrainControl.log(LogMarker.DEBUG, "Unknown biome at {},{}  (chunk {}). Population failed.", x + 15, z + 15, chunkCoord);
-            return;
-        }
-
-        BiomeConfig biomeConfig = biome.getBiomeConfig();
-
-        // Get the random generator
-        WorldConfig worldConfig = configProvider.getWorldConfig();
-        long resourcesSeed = worldConfig.resourcesSeed != 0L ? worldConfig.resourcesSeed : world.getSeed();
-        this.rand.setSeed(resourcesSeed);
-        long l1 = this.rand.nextLong() / 2L * 2L + 1L;
-        long l2 = this.rand.nextLong() / 2L * 2L + 1L;
-        this.rand.setSeed(chunkCoord.getChunkX() * l1 + chunkCoord.getChunkZ() * l2 ^ resourcesSeed);
-
-        // Generate structures
-        boolean hasVillage = world.placeDefaultStructures(rand, chunkCoord);
-
-        // Mark population started
-        world.startPopulation(chunkCoord);
-        TerrainControl.firePopulationStartEvent(world, rand, hasVillage,
-                chunkCoord);
-
-        // Resource sequence
-        for (ConfigFunction<BiomeConfig> res : biomeConfig.resourceSequence)
-        {
-            if (res instanceof Resource)
-                ((Resource) res).process(world, rand, hasVillage, chunkCoord);
-        }
-
-        // Animals
-        world.placePopulationMobs(biome, rand, chunkCoord);
-
-        // Snow and ice
-        new FrozenSurfaceHelper(world).freezeChunk(chunkCoord);
-
-        // Replace blocks
-        world.replaceBlocks(chunkCoord);
-
-        // Mark population ended
-        TerrainControl.firePopulationEndEvent(world, rand, hasVillage, chunkCoord);
-        world.endPopulation();
+    {        
+		if (!processing)
+		{
+			processing = true;
+        
+	        // Get the corner block coords
+	        int x = chunkCoord.getChunkX() * 16;
+	        int z = chunkCoord.getChunkZ() * 16;
+			
+	        // Get the biome of the other corner
+	        LocalBiome biome = world.getBiome(x + 15, z + 15);
+	
+	        // Null check
+	        if (biome == null)
+	        {
+	            TerrainControl.log(LogMarker.DEBUG, "Unknown biome at {},{}  (chunk {}). Population failed.", x + 15, z + 15, chunkCoord);
+	            return;
+	        }
+	        
+	        BiomeConfig biomeConfig = biome.getBiomeConfig();
+	
+	        // Get the random generator
+	        WorldConfig worldConfig = configProvider.getWorldConfig();
+	        long resourcesSeed = worldConfig.resourcesSeed != 0L ? worldConfig.resourcesSeed : world.getSeed();
+	        this.rand.setSeed(resourcesSeed);
+	        long l1 = this.rand.nextLong() / 2L * 2L + 1L;
+	        long l2 = this.rand.nextLong() / 2L * 2L + 1L;
+	        this.rand.setSeed(chunkCoord.getChunkX() * l1 + chunkCoord.getChunkZ() * l2 ^ resourcesSeed);
+	
+	        // Generate structures
+	        boolean hasVillage = world.placeDefaultStructures(rand, chunkCoord);
+	
+	        // Mark population started
+	        world.startPopulation(chunkCoord);
+	        TerrainControl.firePopulationStartEvent(world, rand, hasVillage, chunkCoord);
+	        
+	        // Resource sequence
+	        for (ConfigFunction<BiomeConfig> res : biomeConfig.resourceSequence)
+	        {
+	            if (res instanceof Resource)
+	            {
+	                ((Resource) res).process(world, rand, hasVillage, chunkCoord);
+	            }
+	        }
+	        
+	        // Animals
+	        world.placePopulationMobs(biome, rand, chunkCoord);       
+	        
+	        // Snow and ice
+	        new FrozenSurfaceHelper(world).freezeChunk(chunkCoord);
+	
+	        // Replace blocks
+	        world.replaceBlocks(chunkCoord);
+	        
+	        // Mark population ended
+	        TerrainControl.firePopulationEndEvent(world, rand, hasVillage, chunkCoord);
+	        world.endPopulation();
+	        
+			processing = false;
+		} else {			
+			TerrainControl.log(LogMarker.INFO,"Error, minecraft engine attempted to populate two chunks at once! Chunk X" + chunkCoord.getChunkX() + " Z" + chunkCoord.getChunkZ() + ". This is probably caused by a mod spawning blocks in unloaded chunks and can cause lag as well as missing trees, ores and other TC resources. Please try to find out which mod causes this, disable the feature causing it and alert the mod creator. Set the log level to Debug in mods/TerrainControl/TerranControl.ini file for a stack trace.");
+			TerrainControl.log(LogMarker.DEBUG, Arrays.toString(Thread.currentThread().getStackTrace()));
+		}
     }
 
 }

--- a/platforms/bukkit/src/main/java/com/khorn/terraincontrol/bukkit/BukkitWorld.java
+++ b/platforms/bukkit/src/main/java/com/khorn/terraincontrol/bukkit/BukkitWorld.java
@@ -917,18 +917,18 @@ public class BukkitWorld implements LocalWorld
         return new MojangStructurePart(name, mojangStructurePart);
     }
 
-    // Below methods are only used by Forge (yes that violates the interface segregation principle, I know, don't care...)
+    // Forge only (yes that violates the interface segregation principle, I know)
     
     @Override
     public LocalBiome createBiomeFor(BiomeConfig biomeConfig, BiomeIds biomeIds, ConfigProvider configProvider)
     {
     	return createBiomeFor(biomeConfig, biomeIds);
-    }
+	}
 
     @Override
     public void mergeVanillaBiomeMobSpawnSettings(BiomeConfigStub biomeConfigStub) { }
-
-    // TODO: Forge only atm, someome make a Bukkit implementation plx!
+    
+    // TODO: Forge only atm, someone make a Bukkit implementation plx!
     
 	@Override
 	public void SpawnEntity(EntityFunction entityData) {

--- a/platforms/forge/src/main/java/com/khorn/terraincontrol/forge/ForgeEngine.java
+++ b/platforms/forge/src/main/java/com/khorn/terraincontrol/forge/ForgeEngine.java
@@ -8,6 +8,7 @@ import com.khorn.terraincontrol.LocalWorld;
 import com.khorn.terraincontrol.TerrainControlEngine;
 import com.khorn.terraincontrol.configuration.standard.PluginStandardValues;
 import com.khorn.terraincontrol.exception.InvalidConfigException;
+import com.khorn.terraincontrol.forge.generator.Pregenerator;
 import com.khorn.terraincontrol.util.minecraftTypes.DefaultMaterial;
 
 import net.minecraft.util.ResourceLocation;
@@ -15,6 +16,9 @@ import net.minecraft.world.biome.Biome;
 
 public class ForgeEngine extends TerrainControlEngine
 {
+	public int WorldBorderRadius; // Find a better place for this (It's Forge only so shouldn't be in TerrainControl.java)
+	
+	protected Pregenerator pregenerator;
 
     protected WorldLoader worldLoader;
 
@@ -24,6 +28,7 @@ public class ForgeEngine extends TerrainControlEngine
     {
         super(new ForgeLogger());
         this.worldLoader = worldLoader;
+        pregenerator = new Pregenerator();
     }
 
     // Used to bypass Forge's API in order to properly register a virtual biome
@@ -36,6 +41,11 @@ public class ForgeEngine extends TerrainControlEngine
         Biome.REGISTRY.inverseObjectRegistry.put(biome, resourceLocation);
     }
 
+    public Pregenerator getPregenerator()
+    {
+    	return pregenerator;
+    }
+    
     @Override
     public LocalWorld getWorld(String name)
     {

--- a/platforms/forge/src/main/java/com/khorn/terraincontrol/forge/TCPlugin.java
+++ b/platforms/forge/src/main/java/com/khorn/terraincontrol/forge/TCPlugin.java
@@ -111,7 +111,13 @@ public class TCPlugin
         };
         MinecraftForge.EVENT_BUS.register(new BiomeColorsListener(getBiomeConfig));
 
-        MinecraftForge.EVENT_BUS.register(new GuiHandler());  
+        // Register server tick handler for pre-generation of worlds
+        MinecraftForge.EVENT_BUS.register(new ServerEventListener());
+                
+        MinecraftForge.EVENT_BUS.register(new GuiHandler());
+        
+        // Register KeyBoardEventListener for toggling pre-generator in-game UI using F3
+        MinecraftForge.EVENT_BUS.register(new KeyBoardEventListener());
         
         // Register to our own events, so that they can be fired again as Forge events.
         engine.registerEventHandler(new TCToForgeEventConverter(), EventPriority.CANCELABLE);

--- a/platforms/forge/src/main/java/com/khorn/terraincontrol/forge/events/KeyBoardEventListener.java
+++ b/platforms/forge/src/main/java/com/khorn/terraincontrol/forge/events/KeyBoardEventListener.java
@@ -1,0 +1,36 @@
+package com.khorn.terraincontrol.forge.events;
+
+import org.lwjgl.input.Keyboard;
+
+import com.khorn.terraincontrol.TerrainControl;
+import com.khorn.terraincontrol.forge.ForgeEngine;
+
+import net.minecraft.client.settings.KeyBinding;
+import net.minecraftforge.fml.client.FMLClientHandler;
+import net.minecraftforge.fml.client.registry.ClientRegistry;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.gameevent.InputEvent.KeyInputEvent;
+
+public class KeyBoardEventListener
+{	
+	// Used for pre-generator in-game UI toggle (F3)
+	
+	KeyBinding keyBinding = null;
+	public KeyBoardEventListener()
+	{
+		keyBinding = new KeyBinding("TC Pregenerator HUD toggle", Keyboard.KEY_F3, "TerrainControl");
+		ClientRegistry.registerKeyBinding(keyBinding);
+	}
+
+	@SubscribeEvent
+	public void onKeyInput(KeyInputEvent event)
+	{
+		if (FMLClientHandler.instance().getClient().inGameHasFocus)
+		{
+			if (keyBinding.isPressed())
+			{
+				((ForgeEngine)TerrainControl.getEngine()).getPregenerator().ToggleIngameUI();
+			}
+		}
+	}
+}

--- a/platforms/forge/src/main/java/com/khorn/terraincontrol/forge/events/ServerEventListener.java
+++ b/platforms/forge/src/main/java/com/khorn/terraincontrol/forge/events/ServerEventListener.java
@@ -1,0 +1,20 @@
+package com.khorn.terraincontrol.forge.events;
+
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.gameevent.TickEvent.Phase;
+import net.minecraftforge.fml.common.gameevent.TickEvent.ServerTickEvent;
+
+import com.khorn.terraincontrol.TerrainControl;
+import com.khorn.terraincontrol.forge.ForgeEngine;
+
+public class ServerEventListener
+{	
+	@SubscribeEvent
+	public void onServerTick(ServerTickEvent event)
+	{	
+		if(event.phase == Phase.END)
+		{
+			((ForgeEngine)TerrainControl.getEngine()).getPregenerator().ProcessTick();
+		}	
+	}	
+}

--- a/platforms/forge/src/main/java/com/khorn/terraincontrol/forge/events/WorldListener.java
+++ b/platforms/forge/src/main/java/com/khorn/terraincontrol/forge/events/WorldListener.java
@@ -1,5 +1,7 @@
 package com.khorn.terraincontrol.forge.events;
 
+import com.khorn.terraincontrol.TerrainControl;
+import com.khorn.terraincontrol.forge.ForgeEngine;
 import com.khorn.terraincontrol.forge.ForgeWorld;
 import com.khorn.terraincontrol.forge.WorldLoader;
 import com.khorn.terraincontrol.forge.util.WorldHelper;
@@ -18,6 +20,12 @@ public class WorldListener
         this.worldLoader = worldLoader;
     }
 
+	@SubscribeEvent
+	public void onWorldSave(WorldEvent.Save event)
+	{
+		((ForgeEngine)TerrainControl.getEngine()).getPregenerator().SavePreGeneratorData(event.getWorld());
+	}
+    
     // TODO: This method should not be called by DimensionManager when switching dimensions (main -> nether -> main). Find out why it is being called
     @SubscribeEvent
     public void onWorldUnload(WorldEvent.Unload event)
@@ -30,6 +38,7 @@ public class WorldListener
         }
         if(mcWorld.provider.getDimension() == 0) // Temporary fix, this may break multi-world support (I assume it uses dimensions to load other worlds?) 
         {
+        	((ForgeEngine)TerrainControl.getEngine()).getPregenerator().SavePreGeneratorData(mcWorld);
         	this.worldLoader.unloadWorld(forgeWorld);
         }
     }

--- a/platforms/forge/src/main/java/com/khorn/terraincontrol/forge/generator/BiomeGenCustom.java
+++ b/platforms/forge/src/main/java/com/khorn/terraincontrol/forge/generator/BiomeGenCustom.java
@@ -11,8 +11,12 @@ import com.khorn.terraincontrol.forge.util.MobSpawnGroupHelper;
 import com.khorn.terraincontrol.logging.LogMarker;
 import com.khorn.terraincontrol.util.helpers.StringHelper;
 
+import net.minecraft.init.Biomes;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.biome.Biome;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -109,7 +113,7 @@ public class BiomeGenCustom extends Biome
             forgeEngine.registerForgeBiome(MAX_TC_BIOME_ID, maxTcBiomeKey,
                     new BiomeGenCustom(biomeConfig, new BiomeIds(MAX_TC_BIOME_ID, MAX_TC_BIOME_ID)));
         }
-
+       
         if (biomeIds.isVirtual())
         {
             // Virtual biomes hack: register, then let original biome overwrite
@@ -156,6 +160,34 @@ public class BiomeGenCustom extends Biome
     {
         return "BiomeGenCustom of " + getBiomeName();
     }
+   
+    // Fix for swamp colors (there's a custom noise applied to swamp colors)
+    // TODO: Make these colors configurable via the BiomeConfig
+    @SideOnly(Side.CLIENT)
+    public int getGrassColorAtPos(BlockPos pos)
+    {
+    	if(this.getBiomeName().equals("Swampland"))
+    	{
+	        double d0 = GRASS_COLOR_NOISE.getValue((double)pos.getX() * 0.0225D, (double)pos.getZ() * 0.0225D);
+	        return d0 < -0.1D ? 5011004 : 6975545;
+    	} else {
+    		return super.getGrassColorAtPos(pos);
+    	}
+    }
+    
+    // Fix for swamp colors (there's a custom noise applied to swamp colors)
+    // TODO: Make these colors configurable via the BiomeConfig
+    @SideOnly(Side.CLIENT)
+    public int getFoliageColorAtPos(BlockPos pos)
+    {
+    	if(this.getBiomeName().equals("Swampland"))
+    	{
+    		return 6975545;
+    	} else {
+    		return super.getFoliageColorAtPos(pos);
+    	}
+    }
+
    
     // Adds the mobs to the internal list
     protected void addMobs(List<SpawnListEntry> internalList, List<WeightedMobSpawnGroup> configList)//, boolean improvedMobSpawning)

--- a/platforms/forge/src/main/java/com/khorn/terraincontrol/forge/generator/Cartographer.java
+++ b/platforms/forge/src/main/java/com/khorn/terraincontrol/forge/generator/Cartographer.java
@@ -1,0 +1,635 @@
+package com.khorn.terraincontrol.forge.generator;
+
+import net.minecraft.util.math.BlockPos;
+
+import com.khorn.terraincontrol.LocalMaterialData;
+import com.khorn.terraincontrol.TerrainControl;
+import com.khorn.terraincontrol.exception.InvalidConfigException;
+import com.khorn.terraincontrol.forge.ForgeWorld;
+import com.khorn.terraincontrol.util.ChunkCoordinate;
+import com.khorn.terraincontrol.util.minecraftTypes.DefaultMaterial;
+
+public class Cartographer
+{ 
+	/**
+	 * Spawns a miniature of the known world at 1/16 scale (so one block per chunk) at spawn, made of 
+	 * colored clay, wool and glass. Work in progress, will add more features for spawning location, 
+	 * updating blocks, console commands etc.
+	 */
+    public static void CreateBlockWorldMapAtSpawn(ForgeWorld world, ChunkCoordinate chunkCoord)
+    {
+    	String replaceByMaterial = "159"; // Glass = 95, Clay = 159, Wool = 35 
+    	
+    	BlockPos spawnPoint =  world.getSpawnPoint();
+    	ChunkCoordinate spawnChunk = ChunkCoordinate.fromBlockCoords(spawnPoint.getX(), spawnPoint.getZ());
+    	
+    	// Draw a map of the world at spawn using blocks
+    	int highestBlockY = world.getHighestBlockYAt(chunkCoord.getBlockXCenter(), chunkCoord.getBlockZCenter());
+    	LocalMaterialData material = null;
+    	LocalMaterialData topMaterial = null;
+    	// Find the appropriate blocks to place on the map for the given material.
+    	// If a block cannot be found (because the material is unknown or has no replace-to block)
+    	// try lower blocks until a block is found or the world depth is reached.
+    	while(material == null && highestBlockY >= 0)
+    	{
+    		LocalMaterialData materialToReplace = world.getMaterial(chunkCoord.getBlockXCenter(), highestBlockY, chunkCoord.getBlockZCenter());
+    		
+    		// For trees/water/lava/ice/wood the top block is wool or glass, for everything else it's clay
+        	String replaceByMaterialTop = replaceByMaterial;
+        	if(materialToReplace != null)
+        	{
+    	    	DefaultMaterial defaultMaterialToReplace = materialToReplace.toDefaultMaterial();
+    	    	if(
+    				defaultMaterialToReplace.equals(DefaultMaterial.WATER) || 
+    				defaultMaterialToReplace.equals(DefaultMaterial.STATIONARY_WATER) ||
+    				defaultMaterialToReplace.equals(DefaultMaterial.LAVA) || 
+    				defaultMaterialToReplace.equals(DefaultMaterial.STATIONARY_LAVA) ||
+    				defaultMaterialToReplace.equals(DefaultMaterial.MAGMA) ||
+    				defaultMaterialToReplace.equals(DefaultMaterial.ICE)
+    			)
+    	    	{
+    	    		replaceByMaterialTop = "95";
+    	    	}
+    	    	if(
+    				defaultMaterialToReplace.equals(DefaultMaterial.LEAVES) ||
+    				defaultMaterialToReplace.equals(DefaultMaterial.LEAVES_2) ||
+    				defaultMaterialToReplace.equals(DefaultMaterial.LOG) ||
+    				defaultMaterialToReplace.equals(DefaultMaterial.LOG_2) ||
+    	    		defaultMaterialToReplace.equals(DefaultMaterial.WOOD) ||
+    				defaultMaterialToReplace.equals(DefaultMaterial.WOOD_DOUBLE_STEP) ||
+					defaultMaterialToReplace.equals(DefaultMaterial.WOOD_STEP) ||
+					defaultMaterialToReplace.equals(DefaultMaterial.SPRUCE_WOOD_STAIRS) ||
+					defaultMaterialToReplace.equals(DefaultMaterial.BIRCH_WOOD_STAIRS) ||
+					defaultMaterialToReplace.equals(DefaultMaterial.JUNGLE_WOOD_STAIRS) ||
+					defaultMaterialToReplace.equals(DefaultMaterial.ACACIA_STAIRS) ||
+					defaultMaterialToReplace.equals(DefaultMaterial.DARK_OAK_STAIRS)
+    			)
+    	    	{
+    	    		replaceByMaterialTop = "35";
+    	    	}    	    	
+        	}
+    		
+    		topMaterial = GetReplaceByMaterial(materialToReplace, replaceByMaterialTop);
+    		material = GetReplaceByMaterial(materialToReplace, replaceByMaterial);
+    		if(material != null && topMaterial == null)
+    		{
+    			topMaterial = GetReplaceByMaterial(materialToReplace, replaceByMaterialTop);
+    		}
+    		highestBlockY--;
+    	}    	
+    	
+    	// Couldn't find a block, use black.
+    	if(highestBlockY < 0)
+    	{
+    		highestBlockY = world.getHighestBlockYAt(chunkCoord.getBlockXCenter(), chunkCoord.getBlockZCenter()) - 1;
+			try {
+				material = TerrainControl.readMaterial(replaceByMaterial + ":15");
+				topMaterial = material;
+			} catch (InvalidConfigException e) {
+				e.printStackTrace();
+				return;
+			}
+    	}
+
+    	// Apply 1/16 to height and get Y, take into account height of spawn location
+    	int baseHeight = spawnPoint.getY();
+    	int heightDiff = (int) Math.floor(((highestBlockY + 1) - baseHeight) / 16);
+    	
+    	// Set top block
+    	int newY = baseHeight + heightDiff + TerrainControl.getPluginConfig().CartographerHeightOffset;
+    	world.setBlock(spawnChunk.getBlockXCenter() + chunkCoord.getChunkX(), newY, spawnChunk.getBlockZCenter() + chunkCoord.getChunkZ(), topMaterial);
+    	    	
+    	// Set lower blocks
+    	while(newY >= (baseHeight + TerrainControl.getPluginConfig().CartographerHeightOffset - (int) Math.floor(baseHeight / 16)))
+    	{
+    		newY--;
+   			world.setBlock(spawnChunk.getBlockXCenter() + chunkCoord.getChunkX(), newY, spawnChunk.getBlockZCenter() + chunkCoord.getChunkZ(), material);
+    	}
+    
+    	// Put a glowstone block at spawn
+    	if(chunkCoord.equals(spawnChunk))
+    	{
+    		try {
+    			world.setBlock(spawnChunk.getBlockXCenter() + chunkCoord.getChunkX(), baseHeight + heightDiff + TerrainControl.getPluginConfig().CartographerHeightOffset + 1, spawnChunk.getBlockZCenter() + chunkCoord.getChunkZ(), TerrainControl.readMaterial("GLOWSTONE"));
+			} catch (InvalidConfigException e) {
+				e.printStackTrace();
+			}
+    	}
+    }
+    
+    /**
+     * Gets the block to place on the map based on the given material.
+     */
+    private static LocalMaterialData GetReplaceByMaterial(LocalMaterialData materialToReplace, String replaceByMaterial)
+    {    	
+		DefaultMaterial[] TransparentBlocks = { 
+		};
+
+		DefaultMaterial[] WhiteBlocks = {
+    		DefaultMaterial.SNOW,
+    		DefaultMaterial.SNOW_BLOCK
+		};
+		
+		DefaultMaterial[] OrangeBlocks = {
+    		DefaultMaterial.SAND,
+    	    DefaultMaterial.RED_SANDSTONE,
+    	    DefaultMaterial.HARD_CLAY,
+    	    DefaultMaterial.RED_SANDSTONE_STAIRS
+		};
+		
+	    DefaultMaterial[] MagentaBlocks = {
+    	    DefaultMaterial.PURPUR_BLOCK,
+    	    DefaultMaterial.PURPUR_PILLAR,
+    	    DefaultMaterial.PURPUR_STAIRS,
+    	    DefaultMaterial.PURPUR_DOUBLE_SLAB,
+    	    DefaultMaterial.PURPUR_SLAB
+	    };
+		
+	    DefaultMaterial[] LightBlueBlocks = {
+	    		DefaultMaterial.PACKED_ICE
+	    };
+		
+		DefaultMaterial[] YellowBlocks = {
+    		DefaultMaterial.SAND,
+    		DefaultMaterial.SANDSTONE,
+    		DefaultMaterial.SANDSTONE_STAIRS
+		};
+		
+		DefaultMaterial[] LimeBlocks = {
+			DefaultMaterial.LEAVES,
+			DefaultMaterial.LEAVES_2
+		};
+		
+		DefaultMaterial[] PinkBlocks = {
+    		DefaultMaterial.NETHERRACK,
+    		DefaultMaterial.MYCEL
+		};
+		
+		DefaultMaterial[] GrayBlocks = {
+    		DefaultMaterial.COBBLESTONE,
+    		DefaultMaterial.COBBLESTONE_STAIRS,
+    		DefaultMaterial.MOSSY_COBBLESTONE,
+    	    DefaultMaterial.STONE_SLAB2,
+    	    DefaultMaterial.DOUBLE_STONE_SLAB2,
+    	    DefaultMaterial.STEP,
+    		DefaultMaterial.DOUBLE_STEP,
+    		DefaultMaterial.BRICK,
+    	    DefaultMaterial.BRICK_STAIRS,
+    		DefaultMaterial.SMOOTH_BRICK,
+    	    DefaultMaterial.SMOOTH_STAIRS,
+		};
+		
+		DefaultMaterial[] LightGrayBlocks = {
+    		DefaultMaterial.STONE,
+    		DefaultMaterial.GRAVEL,
+    	    DefaultMaterial.CLAY,
+    	    DefaultMaterial.EMERALD_ORE,
+    	    DefaultMaterial.EMERALD_BLOCK,
+    	    DefaultMaterial.REDSTONE_ORE,
+    	    DefaultMaterial.GLOWING_REDSTONE_ORE,
+    	    DefaultMaterial.DIAMOND_ORE,
+    	    DefaultMaterial.DIAMOND_BLOCK,
+    		DefaultMaterial.GOLD_ORE,
+    	    DefaultMaterial.IRON_ORE,
+    	    DefaultMaterial.COAL_ORE,
+    	    DefaultMaterial.COAL_BLOCK,
+    	    DefaultMaterial.LAPIS_ORE,
+    	    DefaultMaterial.LAPIS_BLOCK,
+    	    DefaultMaterial.GOLD_BLOCK,
+    	    DefaultMaterial.IRON_BLOCK,
+    	    DefaultMaterial.REDSTONE_BLOCK,
+    	    DefaultMaterial.QUARTZ_ORE,
+    	    DefaultMaterial.QUARTZ_BLOCK,
+    	    DefaultMaterial.QUARTZ_STAIRS,    	    
+		};
+		
+		DefaultMaterial[] CyanBlocks = {
+    		DefaultMaterial.FROSTED_ICE,
+    		DefaultMaterial.ICE
+		};
+		
+		DefaultMaterial[] PurpleBlocks = {
+    	    DefaultMaterial.NETHER_BRICK,
+    	    DefaultMaterial.NETHER_BRICK_STAIRS
+		};
+		
+	    DefaultMaterial[] BlueBlocks = {    		
+    	    DefaultMaterial.WATER,
+    	    DefaultMaterial.STATIONARY_WATER
+	    };
+	    
+	    DefaultMaterial[] BrownBlocks = {
+    		DefaultMaterial.DIRT,
+    		DefaultMaterial.WOOD,
+    	    DefaultMaterial.WOOD_DOUBLE_STEP,
+    	    DefaultMaterial.WOOD_STEP,
+    	    DefaultMaterial.SPRUCE_WOOD_STAIRS,
+    	    DefaultMaterial.BIRCH_WOOD_STAIRS,
+    	    DefaultMaterial.JUNGLE_WOOD_STAIRS,
+    	    DefaultMaterial.ACACIA_STAIRS,
+    	    DefaultMaterial.DARK_OAK_STAIRS,
+    		DefaultMaterial.LOG,
+    		DefaultMaterial.LOG_2,
+    		DefaultMaterial.SOIL,
+    		DefaultMaterial.SOUL_SAND,
+    	    DefaultMaterial.HUGE_MUSHROOM_1,
+    	    DefaultMaterial.HUGE_MUSHROOM_2    	    
+	    };
+	    
+	    DefaultMaterial[] GreenBlocks = {
+    		DefaultMaterial.GRASS,
+    		DefaultMaterial.GRASS_PATH,
+	    };
+		
+		DefaultMaterial[] RedBlocks = {
+    	    DefaultMaterial.LAVA,
+    	    DefaultMaterial.STATIONARY_LAVA,
+    	    DefaultMaterial.MAGMA
+		};
+	    
+	    DefaultMaterial[] BlackBlocks = {
+    		DefaultMaterial.BEDROCK,
+    		DefaultMaterial.OBSIDIAN
+	    };
+		
+		DefaultMaterial[] ColoredBlocks = {
+    	    DefaultMaterial.STAINED_CLAY
+		};
+		
+	    // Ignored
+	    /*
+		DefaultMaterial.GLASS
+		DefaultMaterial.WOOL,
+		DefaultMaterial.AIR,
+
+	    DefaultMaterial.SPONGE
+	    DefaultMaterial.POWERED_RAIL
+	    DefaultMaterial.DETECTOR_RAIL
+	    DefaultMaterial.PISTON_STICKY_BASE
+	    DefaultMaterial.WEB
+	    DefaultMaterial.DEAD_BUSH
+	    DefaultMaterial.PISTON_BASE
+	    DefaultMaterial.BED_BLOCK
+	    DefaultMaterial.NOTE_BLOCK
+	    DefaultMaterial.DISPENSER
+	    DefaultMaterial.PISTON_EXTENSION
+	    DefaultMaterial.PISTON_MOVING_PIECE
+	    DefaultMaterial.BROWN_MUSHROOM
+		DefaultMaterial.RED_ROSE
+		DefaultMaterial.YELLOW_FLOWER
+		DefaultMaterial.LONG_GRASS
+		DefaultMaterial.SAPLING
+		DefaultMaterial.RED_MUSHROOM
+	    DefaultMaterial.TNT
+	    DefaultMaterial.BOOKSHELF
+	    DefaultMaterial.TORCH
+	    DefaultMaterial.FIRE
+	    DefaultMaterial.MOB_SPAWNER
+	    DefaultMaterial.WOOD_STAIRS
+	    DefaultMaterial.CHEST
+	    DefaultMaterial.REDSTONE_WIRE
+	    DefaultMaterial.WORKBENCH
+	    DefaultMaterial.CROPS        	    
+	    DefaultMaterial.FURNACE
+	    DefaultMaterial.BURNING_FURNACE
+	    DefaultMaterial.SIGN_POST
+	    DefaultMaterial.WOODEN_DOOR
+	    DefaultMaterial.LADDER
+	    DefaultMaterial.RAILS
+	    DefaultMaterial.WALL_SIGN
+	    DefaultMaterial.LEVER
+	    DefaultMaterial.STONE_PLATE
+	    DefaultMaterial.IRON_DOOR_BLOCK
+	    DefaultMaterial.WOOD_PLATE
+	    DefaultMaterial.REDSTONE_TORCH_OFF
+	    DefaultMaterial.REDSTONE_TORCH_ON
+	    DefaultMaterial.STONE_BUTTON
+	    DefaultMaterial.CACTUS       	    
+	    DefaultMaterial.SUGAR_CANE_BLOCK
+	    DefaultMaterial.JUKEBOX
+	    DefaultMaterial.FENCE
+	    DefaultMaterial.PUMPKIN
+	    DefaultMaterial.GLOWSTONE
+	    DefaultMaterial.PORTAL
+	    DefaultMaterial.JACK_O_LANTERN
+	    DefaultMaterial.CAKE_BLOCK
+	    DefaultMaterial.DIODE_BLOCK_OFF
+	    DefaultMaterial.DIODE_BLOCK_ON
+	    DefaultMaterial.STAINED_GLASS
+	    DefaultMaterial.TRAP_DOOR
+	    DefaultMaterial.MONSTER_EGGS
+	    DefaultMaterial.IRON_FENCE
+	    DefaultMaterial.THIN_GLASS
+	    DefaultMaterial.MELON_BLOCK
+	    DefaultMaterial.PUMPKIN_STEM
+	    DefaultMaterial.MELON_STEM
+	    DefaultMaterial.VINE
+	    DefaultMaterial.FENCE_GATE
+	    DefaultMaterial.WATER_LILY
+	    DefaultMaterial.NETHER_FENCE
+	    DefaultMaterial.COCOA
+	    DefaultMaterial.NETHER_WARTS
+	    DefaultMaterial.ENCHANTMENT_TABLE
+	    DefaultMaterial.BREWING_STAND
+	    DefaultMaterial.CAULDRON
+	    DefaultMaterial.ENDER_PORTAL
+	    DefaultMaterial.ENDER_PORTAL_FRAME
+	    DefaultMaterial.ENDER_STONE
+	    DefaultMaterial.DRAGON_EGG
+	    DefaultMaterial.REDSTONE_LAMP_OFF
+	    DefaultMaterial.REDSTONE_LAMP_ON
+	    DefaultMaterial.ENDER_CHEST
+	    DefaultMaterial.TRIPWIRE_HOOK
+	    DefaultMaterial.TRIPWIRE
+	    DefaultMaterial.COMMAND
+	    DefaultMaterial.BEACON
+	    DefaultMaterial.COBBLE_WALL
+	    DefaultMaterial.FLOWER_POT
+	    DefaultMaterial.CARROT
+	    DefaultMaterial.POTATO
+	    DefaultMaterial.WOOD_BUTTON
+	    DefaultMaterial.SKULL
+	    DefaultMaterial.ANVIL
+	    DefaultMaterial.TRAPPED_CHEST
+	    DefaultMaterial.GOLD_PLATE
+	    DefaultMaterial.IRON_PLATE
+	    DefaultMaterial.REDSTONE_COMPARATOR_OFF
+	    DefaultMaterial.REDSTONE_COMPARATOR_ON
+	    DefaultMaterial.DAYLIGHT_DETECTOR
+	    DefaultMaterial.HOPPER
+	    DefaultMaterial.ACTIVATOR_RAIL
+	    DefaultMaterial.DROPPER
+	    DefaultMaterial.STAINED_GLASS_PANE
+	    DefaultMaterial.SLIME_BLOCK
+	    DefaultMaterial.BARRIER
+	    DefaultMaterial.IRON_TRAPDOOR       	    
+	    DefaultMaterial.PRISMARINE
+	    DefaultMaterial.SEA_LANTERN
+	    DefaultMaterial.HAY_BLOCK(170),
+	    DefaultMaterial.CARPET
+	    DefaultMaterial.DOUBLE_PLANT
+	    DefaultMaterial.STANDING_BANNER
+	    DefaultMaterial.WALL_BANNER
+	    DefaultMaterial.DAYLIGHT_DETECTOR_INVERTED
+	    DefaultMaterial.SPRUCE_FENCE_GATE
+	    DefaultMaterial.BIRCH_FENCE_GATE
+	    DefaultMaterial.JUNGLE_FENCE_GATE
+	    DefaultMaterial.DARK_OAK_FENCE_GATE
+	    DefaultMaterial.ACACIA_FENCE_GATE
+	    DefaultMaterial.SPRUCE_FENCE
+	    DefaultMaterial.BIRCH_FENCE
+	    DefaultMaterial.JUNGLE_FENCE
+	    DefaultMaterial.DARK_OAK_FENCE
+	    DefaultMaterial.ACACIA_FENCE
+	    DefaultMaterial.SPRUCE_DOOR
+	    DefaultMaterial.BIRCH_DOOR
+	    DefaultMaterial.JUNGLE_DOOR
+	    DefaultMaterial.ACACIA_DOOR
+	    DefaultMaterial.DARK_OAK_DOOR
+	    DefaultMaterial.END_ROD
+	    DefaultMaterial.CHORUS_PLANT
+	    DefaultMaterial.CHORUS_FLOWER        	    
+	    DefaultMaterial.END_BRICKS        	    
+	    DefaultMaterial.BEETROOT_BLOCK        	    
+	    DefaultMaterial.END_GATEWAY
+	    DefaultMaterial.COMMAND_REPEATING
+	    DefaultMaterial.COMMAND_CHAIN
+	    DefaultMaterial.NETHER_WART_BLOCK
+	    DefaultMaterial.RED_NETHER_BRICK
+	    DefaultMaterial.BONE_BLOCK
+	    DefaultMaterial.STRUCTURE_VOID
+	    DefaultMaterial.STRUCTURE_BLOCK
+	    */    
+		
+    	for(DefaultMaterial replacematerial : TransparentBlocks)
+    	{
+    		if(replacematerial.equals(materialToReplace.toDefaultMaterial()))
+    		{
+    			try {
+					return TerrainControl.readMaterial("GLASS");
+				} catch (InvalidConfigException e) {
+					e.printStackTrace();
+					return null;
+				}
+    		}
+    	}
+    	for(DefaultMaterial replacematerial : WhiteBlocks)
+    	{
+    		if(replacematerial.equals(materialToReplace.toDefaultMaterial()))
+    		{
+    			try {
+					return TerrainControl.readMaterial(replaceByMaterial);
+				} catch (InvalidConfigException e) {
+					e.printStackTrace();
+					return null;
+				}
+    		}
+    	}
+    	for(DefaultMaterial replacematerial : OrangeBlocks)
+    	{
+    		if(replacematerial.equals(materialToReplace.toDefaultMaterial()))
+    		{
+    			if(replacematerial.equals(DefaultMaterial.SAND))
+    			{
+    				if(materialToReplace.getBlockData() != 1) { continue; }
+    			}    			
+    			try {
+					return TerrainControl.readMaterial(replaceByMaterial + ":1");
+				} catch (InvalidConfigException e) {
+					e.printStackTrace();
+					return null;
+				}
+    		}
+    	}
+    	for(DefaultMaterial replacematerial : MagentaBlocks)
+    	{
+    		if(replacematerial.equals(materialToReplace.toDefaultMaterial()))
+    		{
+    			try {
+					return TerrainControl.readMaterial(replaceByMaterial + ":2");
+				} catch (InvalidConfigException e) {
+					e.printStackTrace();
+					return null;
+				}
+    		}
+    	}
+    	for(DefaultMaterial replacematerial : LightBlueBlocks)
+    	{
+    		if(replacematerial.equals(materialToReplace.toDefaultMaterial()))
+    		{
+    			try {
+					return TerrainControl.readMaterial(replaceByMaterial + ":3");
+				} catch (InvalidConfigException e) {
+					e.printStackTrace();
+					return null;
+				}
+    		}
+    	}
+    	for(DefaultMaterial replacematerial : YellowBlocks)
+    	{
+    		if(replacematerial.equals(materialToReplace.toDefaultMaterial()))
+    		{
+    			try {
+					return TerrainControl.readMaterial(replaceByMaterial + ":4");
+				} catch (InvalidConfigException e) {
+					e.printStackTrace();
+					return null;
+				}
+    		}
+    	}
+    	for(DefaultMaterial replacematerial : LimeBlocks)
+    	{
+    		if(replacematerial.equals(materialToReplace.toDefaultMaterial()))
+    		{
+    			if(replaceByMaterial == "35") // Use green glass instead of lime for spawning trees on top of clay
+    			{
+    				continue;
+    			}
+    			
+    			try {
+					return TerrainControl.readMaterial(replaceByMaterial + ":5");
+				} catch (InvalidConfigException e) {
+					e.printStackTrace();
+					return null;
+				}
+    		}
+    	}
+    	for(DefaultMaterial replacematerial : PinkBlocks)
+    	{
+    		if(replacematerial.equals(materialToReplace.toDefaultMaterial()))
+    		{
+    			try {
+					return TerrainControl.readMaterial(replaceByMaterial + ":6");
+				} catch (InvalidConfigException e) {
+					e.printStackTrace();
+					return null;
+				}
+    		}
+    	}
+    	for(DefaultMaterial replacematerial : GrayBlocks)
+    	{
+    		if(replacematerial.equals(materialToReplace.toDefaultMaterial()))
+    		{
+    			try {
+					return TerrainControl.readMaterial(replaceByMaterial + ":7");
+				} catch (InvalidConfigException e) {
+					e.printStackTrace();
+					return null;
+				}
+    		}
+    	}
+    	for(DefaultMaterial replacematerial : LightGrayBlocks)
+    	{
+    		if(replacematerial.equals(materialToReplace.toDefaultMaterial()))
+    		{
+    			try {
+					return TerrainControl.readMaterial(replaceByMaterial + ":8");
+				} catch (InvalidConfigException e) {
+					e.printStackTrace();
+					return null;
+				}
+    		}
+    	}
+    	for(DefaultMaterial replacematerial : CyanBlocks)
+    	{
+    		if(replacematerial.equals(materialToReplace.toDefaultMaterial()))
+    		{
+    			try {
+					return TerrainControl.readMaterial(replaceByMaterial + ":9");
+				} catch (InvalidConfigException e) {
+					e.printStackTrace();
+					return null;
+				}
+    		}
+    	}
+    	for(DefaultMaterial replacematerial : PurpleBlocks)
+    	{
+    		if(replacematerial.equals(materialToReplace.toDefaultMaterial()))
+    		{
+    			try {
+					return TerrainControl.readMaterial(replaceByMaterial + ":10");
+				} catch (InvalidConfigException e) {
+					e.printStackTrace();
+					return null;
+				}
+    		}
+    	}
+    	for(DefaultMaterial replacematerial : BlueBlocks)
+    	{
+    		if(replacematerial.equals(materialToReplace.toDefaultMaterial()))
+    		{
+    			try {
+					return TerrainControl.readMaterial(replaceByMaterial + ":11");
+				} catch (InvalidConfigException e) {
+					e.printStackTrace();
+					return null;
+				}
+    		}
+    	}
+    	for(DefaultMaterial replacematerial : BrownBlocks)
+    	{
+    		if(replacematerial.equals(materialToReplace.toDefaultMaterial()))
+    		{
+    			try {
+					return TerrainControl.readMaterial(replaceByMaterial + ":12");
+				} catch (InvalidConfigException e) {
+					e.printStackTrace();
+					return null;
+				}
+    		}
+    	}
+    	for(DefaultMaterial replacematerial : GreenBlocks)
+    	{
+    		if(
+				replacematerial.equals(materialToReplace.toDefaultMaterial()) ||
+    			(replaceByMaterial == "35" && (materialToReplace.toDefaultMaterial().equals(DefaultMaterial.LEAVES) || materialToReplace.toDefaultMaterial().equals(DefaultMaterial.LEAVES_2))) // Use green glass instead of lime for spawning trees on top of clay
+			)
+    		{
+    			try {
+					return TerrainControl.readMaterial(replaceByMaterial + ":13");
+				} catch (InvalidConfigException e) {
+					e.printStackTrace();
+					return null;
+				}
+    		}
+    	}
+    	for(DefaultMaterial replacematerial : RedBlocks)
+    	{
+    		if(replacematerial.equals(materialToReplace.toDefaultMaterial()))
+    		{
+    			try {
+					return TerrainControl.readMaterial(replaceByMaterial + ":14");
+				} catch (InvalidConfigException e) {
+					e.printStackTrace();
+					return null;
+				}
+    		}
+    	}
+    	for(DefaultMaterial replacematerial : BlackBlocks)
+    	{
+    		if(replacematerial.equals(materialToReplace.toDefaultMaterial()))
+    		{
+    			try {
+					return TerrainControl.readMaterial(replaceByMaterial + ":15");
+				} catch (InvalidConfigException e) {
+					e.printStackTrace();
+					return null;
+				}
+    		}
+    	}
+    	for(DefaultMaterial replacematerial : ColoredBlocks)
+    	{
+    		if(replacematerial.equals(materialToReplace.toDefaultMaterial()))
+    		{
+    			try {
+					return TerrainControl.readMaterial(replaceByMaterial + ":" + materialToReplace.getBlockData());
+				} catch (InvalidConfigException e) {
+					e.printStackTrace();
+					return null;
+				}
+    		}
+    	}
+    	
+    	return null;
+    }	
+}

--- a/platforms/forge/src/main/java/com/khorn/terraincontrol/forge/generator/Pregenerator.java
+++ b/platforms/forge/src/main/java/com/khorn/terraincontrol/forge/generator/Pregenerator.java
@@ -1,0 +1,591 @@
+package com.khorn.terraincontrol.forge.generator;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.FontRenderer;
+import net.minecraft.client.gui.Gui;
+import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraft.world.WorldServer;
+import net.minecraft.world.WorldType;
+import net.minecraft.world.chunk.storage.RegionFileCache;
+import net.minecraft.world.gen.ChunkProviderServer;
+import net.minecraftforge.fml.common.FMLCommonHandler;
+
+import com.google.common.base.Strings;
+import com.khorn.terraincontrol.LocalWorld;
+import com.khorn.terraincontrol.TerrainControl;
+import com.khorn.terraincontrol.configuration.ConfigProvider;
+import com.khorn.terraincontrol.configuration.WorldConfig;
+import com.khorn.terraincontrol.logging.LogMarker;
+import com.khorn.terraincontrol.util.ChunkCoordinate;
+
+public class Pregenerator
+{    
+	public int PregenerationRadius;
+	    
+    public void resetPregenerator()
+    {
+		left = 0;
+		right = 0;
+		top = 0;
+		bottom = 0;
+		spawned = 1;
+		cycle = 0;
+		iLeft = Integer.MIN_VALUE;
+		iRight = Integer.MIN_VALUE;
+		iTop = Integer.MIN_VALUE;
+		iBottom = Integer.MIN_VALUE;
+		
+		startTime = System.currentTimeMillis();		
+    }	
+	
+	boolean PreGeneratorIsRunning;	    
+	boolean processing = false;
+	
+    int radius = 0;
+    int currentX;
+    int currentZ;    
+    
+    long startTime;
+    
+	int spawned = 1;
+	double total;
+
+	int left = 0;
+	int right = 0;
+	int top = 0;
+	int bottom = 0;
+	int cycle = 0;
+	
+	int iLeft = Integer.MIN_VALUE;
+	int iRight = Integer.MIN_VALUE;
+	int iTop = Integer.MIN_VALUE;
+	int iBottom = Integer.MIN_VALUE;
+	
+	int lastWorldHash = 0;
+	
+	// In-game UI
+	String pregenerationWorld = "";
+	String preGeneratorProgressStatus = "";
+	String preGeneratorProgress = "";
+	String progressScreenElapsedTime = "";
+	String progressScreenEstimatedTime = "";
+	int progressScreenWorldSizeInBlocks;
+	
+	public void ProcessTick()
+	{
+		if(!processing)
+		{
+			processing = true;
+
+			MinecraftServer mcServer = FMLCommonHandler.instance().getMinecraftServerInstance();
+			
+			for(WorldServer worldServer : mcServer.worldServers)
+			{				
+				if(worldServer.getWorldInfo().getTerrainType() == WorldType.parseWorldType("TerrainControl") && worldServer.provider.isSurfaceWorld())
+				{					
+					LocalWorld world = TerrainControl.getWorld(worldServer.getWorldInfo().getWorldName());					
+					
+					if(world == null)
+					{
+						TerrainControl.log(LogMarker.INFO, "Error: Server tick thread failed to load LocalWorld for world \"" + worldServer.getWorldInfo().getWorldName() + "\"");
+						return; // May be unloading / shutting down
+					}
+					
+					ConfigProvider configProvider = world.getConfigs();
+					
+					if(configProvider == null)
+					{
+						TerrainControl.log(LogMarker.INFO, "Error: Server tick thread failed to load world settings for world \"" + worldServer.getWorldInfo().getWorldName() + "\"");
+						throw new NotImplementedException();						
+					}
+					
+					WorldConfig worldConfig = configProvider.getWorldConfig();
+					
+					if(worldConfig == null)
+					{
+						TerrainControl.log(LogMarker.INFO, "Error: Server tick thread failed to load worldConfig for world \"" + worldServer.getWorldInfo().getWorldName() + "\"");
+						throw new NotImplementedException();
+					}
+
+					if(worldConfig.PreGenerationRadius > 0)
+					{
+						Pregenerate(worldServer, worldConfig.PreGenerationRadius);
+					}
+				}
+			}
+			processing = false;
+		} else {
+			// TODO: Remove processing checks and NotImplementedException after verifying that 
+			// this A. Never happens or B. Happens and is not an error so can be ignored.
+			if(processing)
+			{
+				TerrainControl.log(LogMarker.ERROR, "Server ticked while previous server tick was still being processed. This should not happen!");
+				throw new NotImplementedException();
+			}
+		}
+	}
+	
+	void Pregenerate(WorldServer worldServer, int pregenerationRadius)
+	{	
+		// Load any saved pre-generator data and/or set the default values
+		// Don't load the same world each tick
+		if(worldServer.hashCode() != lastWorldHash)
+		{
+			LoadPreGeneratorData(worldServer);
+		}
+		lastWorldHash = worldServer.hashCode();	
+		
+    	radius = pregenerationRadius;
+    	total = (radius * 2 + 1) * (radius * 2 + 1);
+		
+    	// Check if there are chunks that need to be pre-generated
+        if(spawned < total && radius > 0)
+        {			    	
+	        currentX = -radius;
+	        currentZ = -radius;				    	
+        	
+			PreGeneratorIsRunning = true;
+	    	pregenerationWorld = worldServer.getWorldInfo().getWorldName();	    	
+	    	      	
+    		// Spawn all chunks within the pre-generation radius 
+            // Spawn chunks in a rectangle around a center block. 
+        	// Rectangle grows: Add row to right, add row to left, add row to bottom, add row to top, repeat.
+        	// TODO: Rewrite to make use of the way MC groups chunks into region files?
+	        
+    		boolean leftEdgeFound = false;
+    		boolean rightEdgeFound = false;
+    		boolean topEdgeFound = false;
+    		boolean bottomEdgeFound = false;
+    			
+    		int maxSpawnPerTick = TerrainControl.getPluginConfig().PregeneratorMaxChunksPerTick;
+    		int spawnedThisTick = 0;
+
+    		BlockPos spawnPoint = worldServer.getSpawnPoint();
+    		ChunkCoordinate spawnChunk = ChunkCoordinate.fromBlockCoords(spawnPoint.getX(), spawnPoint.getZ());
+    		int spawnChunkX = spawnChunk.getChunkX();
+    		int spawnChunkZ = spawnChunk.getChunkZ();
+    		
+			// This cycle might be stopped at any point because of the max chunks per server tick.
+			// Progress within a cycle is tracked using iTop, iBottom, iLeft, iRight
+			while(!(leftEdgeFound && rightEdgeFound && topEdgeFound && bottomEdgeFound))
+			{ 				
+	    		// TODO: Since the first cycle is cycle 1, the centermost chunk (at the spawnpoint) wont be pregenerated.
+	    		// Probably doesnt matter though since that chunk shouldve been populated automatically when the server started
+				cycle += 1;			
+				
+	    		// Check Right
+	    		if(right >= radius)
+	    		{
+	    			rightEdgeFound = true;
+	    		}
+	    		if(!rightEdgeFound && iLeft == Integer.MIN_VALUE && iTop == Integer.MIN_VALUE && iBottom == Integer.MIN_VALUE)
+	    		{
+	    			boolean bSpawned = false;
+	    			for(int i = -top; i <= bottom; i++)
+	    			{
+	    				currentX = spawnChunkX + cycle;
+	    				currentZ = spawnChunkZ + i;		    				
+	    						    				
+						if(i > iRight) // Check if we haven't generated this chunk in a previous server tick
+						{
+							bSpawned = true;
+							iRight = i;
+		    				spawned++;
+		    				
+							PreGenerateChunk(currentX, currentZ, worldServer);
+							
+							spawnedThisTick++;
+			    			if(spawnedThisTick >= maxSpawnPerTick)
+			    			{
+			    				if(i == bottom)
+			    				{
+			    					right++;
+			    				}
+			    				Pause(worldServer);
+			    				return;
+			    			}
+						}
+	    			}
+	    			if(bSpawned)
+	    			{
+	    				right++;
+	    			}
+	    		}	    		
+	    		
+        		// Check Left
+	    		if(left >= radius)
+	    		{
+	    			leftEdgeFound = true;
+	    		}
+	    		if(!leftEdgeFound && iTop == Integer.MIN_VALUE && iBottom == Integer.MIN_VALUE)
+	    		{
+	    			boolean bSpawned = false;
+	    			for(int i = -top; i <= bottom; i++)
+	    			{
+	    				currentX = spawnChunkX - cycle;
+	    				currentZ = spawnChunkZ + i;
+		    							    				
+						if(i > iLeft) // Check if we haven't generated this chunk in a previous server tick
+						{
+							bSpawned = true;
+							iLeft = i;
+							spawned++;
+							
+							PreGenerateChunk(currentX, currentZ, worldServer);
+							
+		    				spawnedThisTick++;
+			    			if(spawnedThisTick >= maxSpawnPerTick)
+			    			{
+			    				if(i == bottom)
+			    				{
+			    					left++;
+			    				}
+			    				Pause(worldServer);
+			    				return;
+			    			}
+						}
+	    			}
+	    			if(bSpawned)
+	    			{
+	    				left++;
+	    			}
+	    		}	    		
+				 
+        		// Check Bottom
+	    		if(bottom >= radius)
+	    		{
+	    			bottomEdgeFound = true;
+	    		}
+	    		if(!bottomEdgeFound && iTop == Integer.MIN_VALUE)
+	    		{
+	    			boolean bSpawned = false;
+	    			for(int i = -left; i <= right; i++)
+	    			{
+	    				currentX = spawnChunkX + i;
+	    				currentZ = spawnChunkZ + cycle;
+		    							    				
+						if(i > iBottom) // Check if we haven't generated this chunk in a previous server tick
+						{
+							bSpawned = true;
+							iBottom = i;
+							spawned++;
+							
+							PreGenerateChunk(currentX, currentZ, worldServer);
+							
+							spawnedThisTick++;
+			    			if(spawnedThisTick >= maxSpawnPerTick)
+			    			{
+			    				if(i == right)
+			    				{
+			    					bottom++;
+			    				}
+			    				Pause(worldServer);
+			    				return;
+			    			}
+						}
+	    			}
+	    			if(bSpawned)
+	    			{
+	    				bottom++;
+	    			}
+	    		}
+
+        		// Check Top
+	    		if(top >= radius)
+	    		{
+	    			topEdgeFound = true;
+	    		}
+	    		if(!topEdgeFound)
+	    		{
+	    			boolean bSpawned = false;
+	    			for(int i = -left; i <= right; i++)
+	    			{
+	    				currentX = spawnChunkX + i;
+	    				currentZ = spawnChunkZ - cycle;	
+
+						if(i > iTop) // Check if we haven't generated this chunk in a previous server tick
+						{
+							bSpawned = true;
+							iTop = i;
+							spawned++;
+							
+							PreGenerateChunk(currentX, currentZ, worldServer);
+							
+		    				spawnedThisTick++;
+			    			if(spawnedThisTick >= maxSpawnPerTick)
+			    			{
+			    				if(i == right)
+			    				{
+			    					top++;
+			    				}
+			    				Pause(worldServer);
+			    				return;
+			    			}
+						}
+	    			}
+	    			if(bSpawned)
+	    			{
+	    				top++;
+	    			}
+	    		}
+	    		
+	    		// Cycle completed, reset cycle progress
+    			iLeft = Integer.MIN_VALUE;
+    			iBottom = Integer.MIN_VALUE;
+    			iRight = Integer.MIN_VALUE;
+    			iTop = Integer.MIN_VALUE;		    			
+			}
+
+			UpdateProgressMessage();
+			
+			SavePreGeneratorData(worldServer);					
+        }
+        PreGeneratorIsRunning = false;
+	}
+	
+	void Pause(WorldServer worldServer)
+	{
+		// Pre-generation cycle cannot be completed.
+		// Save progress so we can continue and retry on the next server tick.
+		cycle -= 1;
+		processing = false;
+	}
+	
+	void PreGenerateChunk(int currentX, int currentZ, WorldServer worldServer)
+	{
+		UpdateProgressMessage();
+		
+		ChunkProviderServer chunkProvider = worldServer.getChunkProvider();
+		
+        if (
+        	!(
+	    		(
+    				chunkProvider.chunkExists(currentX, currentZ) || 
+					RegionFileCache.createOrLoadRegionFile(worldServer.getChunkSaveLocation(), currentX, currentZ).chunkExists(currentX & 0x1F, currentZ & 0x1F)
+				) && 
+				chunkProvider.provideChunk(currentX, currentZ).isPopulated()
+			)
+		)
+		{
+        	chunkProvider.provideChunk(currentX, currentZ).needsSaving(true);
+        	chunkProvider.provideChunk(currentX, currentZ + 1).needsSaving(true);
+        	chunkProvider.provideChunk(currentX + 1, currentZ).needsSaving(true);
+        	chunkProvider.provideChunk(currentX + 1, currentZ + 1).needsSaving(true);			
+		}
+	}
+	
+	void UpdateProgressMessage ()	
+	{
+		long elapsedTime = System.currentTimeMillis() - startTime;
+
+		int hours = (int)Math.floor(elapsedTime / 1000d / 60d / 60d);
+		int minutes = (int)Math.floor(elapsedTime / 1000d / 60d) - (hours * 60);
+		int seconds = (int)Math.floor(elapsedTime / 1000d) - (minutes * 60) - (hours * 60 * 60);
+		
+		String sElapsedTime = (hours < 10 ? "0" + hours : hours) + ":" + (minutes < 10 ? "0" + minutes : minutes) + ":" + (seconds < 10 ? "0" + seconds : seconds);
+
+		double eTA = (total / spawned) * elapsedTime - elapsedTime;
+
+		hours = (int)Math.floor(eTA / 1000d / 60d / 60d);
+		minutes = (int)Math.floor(eTA / 1000d / 60d) - (hours * 60);
+		seconds = (int)Math.floor(eTA / 1000d) - (minutes * 60) - (hours * 60 * 60);
+
+		String estimatedTime = (hours < 10 ? "0" + hours : hours) + ":" + (minutes < 10 ? "0" + minutes : minutes) + ":" + (seconds < 10 ? "0" + seconds : seconds);
+
+		if(spawned < total)
+		{
+	        long i = Runtime.getRuntime().maxMemory();
+	        long j = Runtime.getRuntime().totalMemory();
+	        long k = Runtime.getRuntime().freeMemory();
+	        long l = j - k;
+	        String memoryUsage = " Mem: " + Long.valueOf(l * 100L / i) + "% " + Long.valueOf(BytesToMb(l)) + " / " +  Long.valueOf(BytesToMb(i)) + " MB ";
+	        
+	        progressScreenWorldSizeInBlocks = (radius * 2 + 1) * 16;
+			preGeneratorProgressStatus = (int)spawned + "/" + (int)total; 
+			preGeneratorProgress = (int)Math.round(((spawned / (double)(total)) * 100)) + "";
+			progressScreenElapsedTime = sElapsedTime;
+			progressScreenEstimatedTime = estimatedTime;
+			TerrainControl.log(LogMarker.INFO, "Pre-generating chunk X" + currentX + " Z" + currentZ + ". Radius: " + radius + " Spawned: " + (int)spawned + "/" + (int)total + " " + (int)Math.round(((spawned / (double)(total)) * 100)) + "% done. Elapsed: " + sElapsedTime + " ETA: " + estimatedTime + memoryUsage);	
+		} else {
+			preGeneratorProgressStatus = "Done";
+			preGeneratorProgress = "";
+			progressScreenElapsedTime = "";
+			progressScreenEstimatedTime = "";
+			progressScreenWorldSizeInBlocks = 0;			
+			TerrainControl.log(LogMarker.INFO, "Pre-generating chunks done for world " + pregenerationWorld + ", " + ((int)spawned) + " chunks spawned in " + sElapsedTime);
+		}
+	}
+	
+	public boolean menuOpen = true;
+	public void ShowInGameUI()
+	{
+		if(menuOpen)
+		{
+	    	Minecraft mc = Minecraft.getMinecraft();
+	    	mc.gameSettings.showDebugInfo = false;
+	    	
+	    	if(PreGeneratorIsRunning && preGeneratorProgressStatus != "Done")
+	    	{
+		    	FontRenderer fontRenderer = mc.fontRendererObj;
+		    	
+		        GlStateManager.pushMatrix();
+		        
+		        List<String> list = new ArrayList<String>();       
+		        
+		        list.add("Generating \"" + pregenerationWorld + "\" " + (progressScreenWorldSizeInBlocks > 0 ? "(" + progressScreenWorldSizeInBlocks + "x" + progressScreenWorldSizeInBlocks  + " blocks)" : ""));        
+				list.add("Progress: " + preGeneratorProgress + "%");
+				list.add("Chunks: " + preGeneratorProgressStatus);
+				list.add("Elapsed: " + progressScreenElapsedTime);
+				list.add("Estimated: " + progressScreenEstimatedTime);
+		        
+		        long i = Runtime.getRuntime().maxMemory();
+		        long j = Runtime.getRuntime().totalMemory();
+		        long k = Runtime.getRuntime().freeMemory();
+		        long l = j - k;
+		        list.add("Memory: " + Long.valueOf(BytesToMb(l)) + "/" +  Long.valueOf(BytesToMb(i)) + " MB");
+		
+		        for (int zi = 0; zi < list.size(); ++zi)
+		        {
+		            String s = (String)list.get(zi);
+		
+		            if (!Strings.isNullOrEmpty(s))
+		            {
+		                int zj = fontRenderer.FONT_HEIGHT;
+		                int zk = fontRenderer.getStringWidth(s);
+		                int zi1 = 2 + zj * zi;
+		                Gui.drawRect(1, zi1 - 1, 2 + zk + 1, zi1 + zj - 1, -1873784752); // TODO: Make semi-transparent
+		                fontRenderer.drawString(s, 2, zi1, 14737632);
+		            }
+		        }
+		        GlStateManager.popMatrix();
+	    	}
+		}
+	}	
+
+	public void ToggleIngameUI()
+	{ 
+		if(PreGeneratorIsRunning && preGeneratorProgressStatus != "Done" || menuOpen)
+		{
+			if(menuOpen)
+			{
+				Minecraft.getMinecraft().gameSettings.showDebugInfo = false;
+				menuOpen = false;
+			}
+			else if(!Minecraft.getMinecraft().gameSettings.showDebugInfo)
+			{			
+				menuOpen = true;
+			}
+		}
+	}
+	
+    private long BytesToMb(long bytes)
+    {
+        return bytes / 1024L / 1024L;
+    }
+	
+    // Saving / Loading
+    // TODO: It's crude but it works, feel free to improve
+    
+	public void SavePreGeneratorData(World world)
+	{	
+		if(PreGeneratorIsRunning)
+		{
+			File pregeneratedChunksFile = new File(world.getSaveHandler().getWorldDirectory() + "/TerrainControl/PregeneratedChunks.txt");		
+			if(pregeneratedChunksFile.exists())
+			{
+				pregeneratedChunksFile.delete();
+			}		
+			
+			StringBuilder stringbuilder = new StringBuilder();
+			stringbuilder.append(spawned + "," + left + "," + top + "," + right + "," + bottom + "," + cycle + "," + (System.currentTimeMillis() - startTime) + "," + iTop + "," + iBottom + "," + iLeft + "," + iRight);		
+			
+			BufferedWriter writer = null;
+	        try
+	        {
+	        	pregeneratedChunksFile.getParentFile().mkdirs();
+	        	writer = new BufferedWriter(new FileWriter(pregeneratedChunksFile));
+	            writer.write(stringbuilder.toString());
+	            TerrainControl.log(LogMarker.INFO, "Pre-generator data saved");
+	        }
+	        catch (IOException e)
+	        {
+	        	TerrainControl.log(LogMarker.ERROR, "Could not save pre-generator data.");
+	            e.printStackTrace();
+	        }
+	        finally
+	        {   
+	            try
+	            {           	
+	                writer.close();
+	            } catch (Exception e) { }
+	        }
+		}
+	}
+
+	void LoadPreGeneratorData(WorldServer worldServer)
+	{				
+		File pregeneratedChunksFile = new File(worldServer.getSaveHandler().getWorldDirectory() + "/TerrainControl/PregeneratedChunks.txt");				
+		String[] pregeneratedChunksFileValues = {};
+		if(pregeneratedChunksFile.exists())
+		{
+			try {
+				StringBuilder stringbuilder = new StringBuilder();
+				BufferedReader reader = new BufferedReader(new FileReader(pregeneratedChunksFile));
+				try {
+					String line = reader.readLine();
+	
+				    while (line != null)
+				    {
+				    	stringbuilder.append(line);
+				        line = reader.readLine();
+				    }				    
+				    if(stringbuilder.length() > 0)
+				    {
+				    	pregeneratedChunksFileValues = stringbuilder.toString().split(",");
+				    }
+				    TerrainControl.log(LogMarker.INFO, "Pre-generator data loaded");
+				} finally {
+					reader.close();
+				}
+				
+			} catch (FileNotFoundException e1) {
+				e1.printStackTrace();
+			}
+			catch (IOException e1) {
+				e1.printStackTrace();
+			}
+		}
+				
+		if(pregeneratedChunksFileValues.length > 0)
+		{
+			spawned = Integer.parseInt(pregeneratedChunksFileValues[0]);
+			
+			left = Integer.parseInt(pregeneratedChunksFileValues[1]);
+			top = Integer.parseInt(pregeneratedChunksFileValues[2]);
+			right = Integer.parseInt(pregeneratedChunksFileValues[3]);			
+			bottom = Integer.parseInt(pregeneratedChunksFileValues[4]);
+						
+			cycle = Integer.parseInt(pregeneratedChunksFileValues[5]);
+			startTime = System.currentTimeMillis() - Long.parseLong(pregeneratedChunksFileValues[6]); // Elapsed time
+			
+			iTop = Integer.parseInt(pregeneratedChunksFileValues[7]);
+			iBottom = Integer.parseInt(pregeneratedChunksFileValues[8]);
+			iLeft = Integer.parseInt(pregeneratedChunksFileValues[9]);
+			iRight = Integer.parseInt(pregeneratedChunksFileValues[10]);
+		}
+	}
+}

--- a/platforms/forge/src/main/java/com/khorn/terraincontrol/forge/gui/GuiHandler.java
+++ b/platforms/forge/src/main/java/com/khorn/terraincontrol/forge/gui/GuiHandler.java
@@ -2,7 +2,9 @@ package com.khorn.terraincontrol.forge.gui;
 
 import java.util.HashMap;
 
+import com.khorn.terraincontrol.TerrainControl;
 import com.khorn.terraincontrol.configuration.WorldConfig;
+import com.khorn.terraincontrol.forge.ForgeEngine;
 
 import net.minecraft.client.gui.GuiCreateWorld;
 import net.minecraft.client.gui.GuiMainMenu;
@@ -11,6 +13,7 @@ import net.minecraft.client.gui.GuiWorldSelection;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.world.World;
 import net.minecraftforge.client.event.GuiOpenEvent;
+import net.minecraftforge.client.event.RenderGameOverlayEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.network.IGuiHandler;
 import net.minecraftforge.fml.relauncher.Side;
@@ -31,7 +34,14 @@ public class GuiHandler implements IGuiHandler
     public static HashMap<String,WorldConfig> worlds = new HashMap<String, WorldConfig>();
     public static int pageNumber = 0;
 	
-    public Class<? extends GuiScreen> lastGuiOpened = null;
+    public static Class<? extends GuiScreen> lastGuiOpened = null;
+    
+    @SideOnly(Side.CLIENT)
+    @SubscribeEvent
+    public void renderGameOverLay(RenderGameOverlayEvent.Post event)
+    {
+    	((ForgeEngine)TerrainControl.getEngine()).getPregenerator().ShowInGameUI();
+    }
     
     @SideOnly(Side.CLIENT)
     @SubscribeEvent
@@ -54,24 +64,19 @@ public class GuiHandler implements IGuiHandler
     
     @SideOnly(Side.CLIENT)
     @SubscribeEvent
-    public void closeGui(GuiOpenEvent event)
-    {
-
-    }
+    public void closeGui(GuiOpenEvent event) { }
     
     public void registerKeybindings() {}
 
 	@Override
 	public Object getServerGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z)
 	{
-		// TODO Auto-generated method stub
 		return null;
 	}
 
 	@Override
 	public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z)
 	{
-		// TODO Auto-generated method stub
 		return null;
 	}
 }

--- a/platforms/forge/src/main/java/com/khorn/terraincontrol/forge/gui/TCGuiCreateWorld.java
+++ b/platforms/forge/src/main/java/com/khorn/terraincontrol/forge/gui/TCGuiCreateWorld.java
@@ -3,87 +3,68 @@ package com.khorn.terraincontrol.forge.gui;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
 import java.util.Random;
 
 import org.apache.commons.io.FileUtils;
 import org.lwjgl.input.Keyboard;
 
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
-
 import com.khorn.terraincontrol.TerrainControl;
 import com.khorn.terraincontrol.configuration.WorldConfig;
 import com.khorn.terraincontrol.configuration.io.FileSettingsReader;
-import com.khorn.terraincontrol.configuration.io.FileSettingsWriter;
 import com.khorn.terraincontrol.configuration.io.SettingsMap;
-import com.khorn.terraincontrol.configuration.io.SimpleSettingsMap;
 import com.khorn.terraincontrol.configuration.standard.WorldStandardValues;
-import com.khorn.terraincontrol.forge.TCPlugin;
-import com.khorn.terraincontrol.logging.LogMarker;
+import com.khorn.terraincontrol.forge.ForgeEngine;
 
-import net.minecraft.client.AnvilConverterException;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiButton;
-import net.minecraft.client.gui.GuiDownloadTerrain;
 import net.minecraft.client.gui.GuiErrorScreen;
-import net.minecraft.client.gui.GuiMainMenu;
-import net.minecraft.client.gui.GuiListExtended;
-import net.minecraft.client.gui.GuiScreenWorking;
-import net.minecraft.client.gui.GuiCreateWorld;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.gui.GuiTextField;
-import net.minecraft.client.gui.GuiWorldSelection;
 import net.minecraft.client.gui.GuiYesNo;
 import net.minecraft.client.gui.GuiYesNoCallback;
 import net.minecraft.client.resources.I18n;
-import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.ChatAllowedCharacters;
-import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.GameType;
-import net.minecraft.world.World;
 import net.minecraft.world.WorldSettings;
 import net.minecraft.world.WorldType;
 import net.minecraft.world.storage.ISaveFormat;
 import net.minecraft.world.storage.WorldInfo;
-import net.minecraftforge.client.event.GuiOpenEvent;
 import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.ModContainer;
-import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
-import net.minecraftforge.fml.common.network.IGuiHandler;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
   
 @SideOnly(Side.CLIENT)
 public class TCGuiCreateWorld extends GuiScreen implements GuiYesNoCallback
 {	
-    private GuiScreen sender;
+    GuiScreen sender;
     
-    private GuiTextField txtWorldName;
-    private GuiTextField txtSeed;
+    GuiTextField txtWorldName;
+    GuiTextField txtSeed;
     
-    private GuiButton btnavailableWorld1;
-    private GuiButton btnavailableWorld2;
-    private GuiButton btnavailableWorld3;
-    private GuiButton btnavailableWorldPrev;
-    private GuiButton btnavailableWorldNext;
-    private GuiButton btnavailableWorldNew;
-    private GuiButton btnavailableWorldClone;
+    GuiButton btnavailableWorld1;
+    GuiButton btnavailableWorld2;
+    GuiButton btnavailableWorld3;
+    GuiButton btnavailableWorldPrev;
+    GuiButton btnavailableWorldNext;
+    GuiButton btnavailableWorldNew;
+    GuiButton btnavailableWorldClone;
     
-    private GuiButton btnavailableWorldDelete1;
-    private GuiButton btnavailableWorldDelete2;
-    private GuiButton btnavailableWorldDelete3;          
+    GuiButton btnavailableWorldDelete1;
+    GuiButton btnavailableWorldDelete2;
+    GuiButton btnavailableWorldDelete3;          
+    
+    GuiTextField txtPregenRadius;    
+    GuiTextField txtWorldBorderRadius;   
 
-    private GuiButton btnGameMode;
-    private GuiButton btnAllowCheats;
-    private GuiButton btnBonusChest;
+    GuiButton btnGameMode;
+    GuiButton btnAllowCheats;
+    GuiButton btnBonusChest;
     
-    private GuiButton btnCreateWorld;        
+    GuiButton btnCreateWorld;        
     
-    private boolean bBtnCreateNewWorldClicked;
+    boolean bBtnCreateNewWorldClicked;
     
-    private final String[] field_146327_L = new String[] {"CON", "COM", "PRN", "AUX", "CLOCK$", "NUL", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"};
-    private final String __OBFID = "CL_00000689";
+    final String[] field_146327_L = new String[] {"CON", "COM", "PRN", "AUX", "CLOCK$", "NUL", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"};
 
     public TCGuiCreateWorld(GuiScreen sender)
     {
@@ -96,6 +77,8 @@ public class TCGuiCreateWorld extends GuiScreen implements GuiYesNoCallback
     public void updateScreen()
     {
         this.txtSeed.updateCursorCounter();
+        this.txtWorldBorderRadius.updateCursorCounter();
+        this.txtPregenRadius.updateCursorCounter();
     }
     
     WorldConfig selectedWorldConfig = null;
@@ -253,6 +236,8 @@ public class TCGuiCreateWorld extends GuiScreen implements GuiYesNoCallback
             				selectedWorldConfig = GuiHandler.worlds.get(worldDir.getName());
             				if(GuiHandler.selectedWorldName == null || !GuiHandler.selectedWorldName.equals(GuiHandler.worldName))
             				{	
+            					((ForgeEngine)TerrainControl.getEngine()).getPregenerator().PregenerationRadius = selectedWorldConfig.PreGenerationRadius;
+            					((ForgeEngine)TerrainControl.getEngine()).WorldBorderRadius = selectedWorldConfig.WorldBorderRadius;
             					GuiHandler.seed = selectedWorldConfig.worldSeed;
             					
             					WorldInfo worldInfo = this.mc.getSaveLoader().getWorldInfo(GuiHandler.worldName);
@@ -277,11 +262,15 @@ public class TCGuiCreateWorld extends GuiScreen implements GuiYesNoCallback
             			}
             		}
             	}
-        	}	            
+        	}
             
             if(usingPreset)
             {
             	worldNameHelpText2 = "Using existing settings";
+            	
+                txtPregenRadius.setText(((ForgeEngine)TerrainControl.getEngine()).getPregenerator().PregenerationRadius + "");		                
+                txtWorldBorderRadius.setText(((ForgeEngine)TerrainControl.getEngine()).WorldBorderRadius + "");;
+            	           	
                 txtSeed.setText(GuiHandler.seed);
             } else {
             	GuiHandler.selectedWorldName = null;
@@ -357,7 +346,6 @@ public class TCGuiCreateWorld extends GuiScreen implements GuiYesNoCallback
 	                GuiHandler.pageNumber = 0;
                 	if(GuiHandler.worlds.size() > 0)
                 	{
-                        ArrayList<String> worldNames = new ArrayList<String>();        	            
                         if(TCWorldsDirectory.exists() && TCWorldsDirectory.isDirectory())
                         {
                         	for(File worldDir : TCWorldsDirectory.listFiles())
@@ -371,6 +359,8 @@ public class TCGuiCreateWorld extends GuiScreen implements GuiYesNoCallback
                     	}
                 		selectedWorldConfig = GuiHandler.worlds.get(GuiHandler.selectedWorldName);
 						
+                		((ForgeEngine)TerrainControl.getEngine()).getPregenerator().PregenerationRadius = selectedWorldConfig.PreGenerationRadius;
+                		((ForgeEngine)TerrainControl.getEngine()).WorldBorderRadius = selectedWorldConfig.WorldBorderRadius;
     					GuiHandler.seed = selectedWorldConfig.worldSeed;
     					
     					WorldInfo worldInfo = this.mc.getSaveLoader().getWorldInfo(GuiHandler.selectedWorldName);        					
@@ -386,7 +376,9 @@ public class TCGuiCreateWorld extends GuiScreen implements GuiYesNoCallback
                 		GuiHandler.selectedWorldName = null;
 	                	selectedWorldConfig = null;
 	                	
-	                	GuiHandler.seed = "";							
+	                	GuiHandler.seed = "";
+	                	((ForgeEngine)TerrainControl.getEngine()).WorldBorderRadius = 0;
+	                	((ForgeEngine)TerrainControl.getEngine()).getPregenerator().PregenerationRadius = 0;
                 	}
                 	
 					// Create new world dir?
@@ -402,7 +394,8 @@ public class TCGuiCreateWorld extends GuiScreen implements GuiYesNoCallback
 		else if(askModCompatContinue)
 		{
 			if(ok)
-			{				
+			{		
+				((ForgeEngine)TerrainControl.getEngine()).getPregenerator().resetPregenerator();
 				this.mc.launchIntegratedServer(GuiHandler.worldName, this.txtWorldName.getText().trim(), worldsettings);
 			} else {
 				this.mc.displayGuiScreen(new TCGuiCreateWorld(new TCGuiSelectCreateWorldMode()));
@@ -436,7 +429,6 @@ public class TCGuiCreateWorld extends GuiScreen implements GuiYesNoCallback
 					try {
 						FileUtils.copyDirectory(sourceDir, destDir);
 					} catch (IOException e) {
-						// TODO Auto-generated catch block
 						e.printStackTrace();
 		        		this.mc.displayGuiScreen(new GuiErrorScreen("Error", "Could not copy directory \"" + GuiHandler.selectedWorldName + "\", files may be in use."));
 		        		return;
@@ -455,6 +447,8 @@ public class TCGuiCreateWorld extends GuiScreen implements GuiYesNoCallback
 					txtWorldName.setText(GuiHandler.newWorldName);
 					
 					GuiHandler.seed = "";
+					((ForgeEngine)TerrainControl.getEngine()).WorldBorderRadius = 0;
+					((ForgeEngine)TerrainControl.getEngine()).getPregenerator().PregenerationRadius = 0;
 					
 					GuiHandler.gameModeString = "survival";
 					GuiHandler.hardCore = false;
@@ -480,10 +474,9 @@ public class TCGuiCreateWorld extends GuiScreen implements GuiYesNoCallback
 	        }
 	    }
 	    folder.delete();
-	} 
+	}
 	
-	boolean askDeleteSettings = false;
-	
+	boolean askDeleteSettings = false;	
     public GuiYesNo askDeleteSettings(GuiYesNoCallback p_152129_0_, String worldName)
     {
     	askDeleteSettings = true;
@@ -498,18 +491,21 @@ public class TCGuiCreateWorld extends GuiScreen implements GuiYesNoCallback
         return guiyesno;
     }
     	    	    	    
-    boolean askModCompatContinue = false;
-    
+    boolean askModCompatContinue = false;  
     public GuiYesNo askModCompatContinue(GuiYesNoCallback p_152129_0_, boolean fastcraftEnabled, boolean biomesOPlentyEnabled)
     {
     	askDeleteSettings = false;
     	selectingWorldName = false;	    	
     	askModCompatContinue = true;
     	
-        String s1 = "Biomes o' plenty may cause crashes. ";
+    	String bop = "Biomes o' plenty may cause crashes. ";
+    	String fc = "FastCraft detected, pre-generator";
+    	
+        String s1 = biomesOPlentyEnabled ? bop + (fastcraftEnabled ? fc : "") : (fastcraftEnabled ? fc : "");
+        String s2 = fastcraftEnabled ? "progress screen disabled. Use the launcher log instead." : "";
         String s3 = "Continue";
         String s4 = "Back";
-        GuiYesNo guiyesno = new GuiYesNo(p_152129_0_, s1, "", s3, s4, 0);
+        GuiYesNo guiyesno = new GuiYesNo(p_152129_0_, s1, s2, s3, s4, 0);
         return guiyesno;
     }
     
@@ -523,6 +519,28 @@ public class TCGuiCreateWorld extends GuiScreen implements GuiYesNoCallback
             txtSeed.textboxKeyTyped(p_73869_1_, p_73869_2_);           
             GuiHandler.seed = txtSeed.getText();
         }
+        else if (txtPregenRadius.isFocused())
+        {
+            txtPregenRadius.textboxKeyTyped(p_73869_1_, p_73869_2_);
+            try
+            {
+            	((ForgeEngine)TerrainControl.getEngine()).getPregenerator().PregenerationRadius = Integer.parseInt(txtPregenRadius.getText());
+            } catch(NumberFormatException ex)
+            {
+            	((ForgeEngine)TerrainControl.getEngine()).getPregenerator().PregenerationRadius = 0; 
+            }
+        }
+        else if (txtWorldBorderRadius.isFocused())
+        {
+            txtWorldBorderRadius.textboxKeyTyped(p_73869_1_, p_73869_2_);
+            try
+            {
+            	((ForgeEngine)TerrainControl.getEngine()).WorldBorderRadius = Integer.parseInt(txtWorldBorderRadius.getText());
+            } catch(NumberFormatException ex)
+            {
+            	((ForgeEngine)TerrainControl.getEngine()).WorldBorderRadius = 0; 
+            }
+        }        
 
         if (p_73869_2_ == 28 || p_73869_2_ == 156)
         {
@@ -542,6 +560,8 @@ public class TCGuiCreateWorld extends GuiScreen implements GuiYesNoCallback
 
         this.txtSeed.mouseClicked(p_73864_1_, p_73864_2_, p_73864_3_);
         this.txtWorldName.mouseClicked(p_73864_1_, p_73864_2_, p_73864_3_);
+        this.txtPregenRadius.mouseClicked(p_73864_1_, p_73864_2_, p_73864_3_);
+        this.txtWorldBorderRadius.mouseClicked(p_73864_1_, p_73864_2_, p_73864_3_);
     }
 
     WorldSettings worldsettings = null;
@@ -618,7 +638,7 @@ public class TCGuiCreateWorld extends GuiScreen implements GuiYesNoCallback
         	if (button.id == 7) // Next 
         	{
         		nextPage();
-        	}            	
+        	}
             if (button.id == 1) // Cancel
             {
                 this.mc.displayGuiScreen(this.sender);
@@ -668,7 +688,7 @@ public class TCGuiCreateWorld extends GuiScreen implements GuiYesNoCallback
                 if(GuiHandler.allowCheats)
                 {
                 	worldsettings.enableCommands();
-                }
+                }                                  
                 
                 // Clear existing pre-generator and structurecache data
                 // Do this here in the Forge layer instead of in common since this only applies to Forge atm.
@@ -742,11 +762,17 @@ public class TCGuiCreateWorld extends GuiScreen implements GuiYesNoCallback
     				}
     			}
     			
-    			if(biomesOPlentyEnabled)
+    			if(((ForgeEngine)TerrainControl.getEngine()).getPregenerator().PregenerationRadius > 0 && fastcraftEnabled)
+    			{
+					GuiYesNo guiyesno = askModCompatContinue(this, fastcraftEnabled, biomesOPlentyEnabled);
+					this.mc.displayGuiScreen(guiyesno);
+    			}
+    			else if(biomesOPlentyEnabled)
             	{
 					GuiYesNo guiyesno = askModCompatContinue(this, false, biomesOPlentyEnabled);
 					this.mc.displayGuiScreen(guiyesno);        				
-				} else {					
+				} else {				
+					((ForgeEngine)TerrainControl.getEngine()).getPregenerator().resetPregenerator();
     				this.mc.launchIntegratedServer(GuiHandler.worldName, this.txtWorldName.getText().trim(), worldsettings);
     			}
             }
@@ -840,12 +866,7 @@ public class TCGuiCreateWorld extends GuiScreen implements GuiYesNoCallback
         	btnAllowCheats.displayString = btnAllowCheats.displayString + I18n.format("options.off", new Object[0]);
         }
     }
-    
-    // Move the other controls for the time being (until the remaining buttons are fixed)
-    int heightOffset = 17;
-    int heightOffset1 = 43;
-    int heightOffset2 = 5;
-    
+        
     /**
      * Adds the buttons (and other controls) to the screen in question.
      */
@@ -856,31 +877,31 @@ public class TCGuiCreateWorld extends GuiScreen implements GuiYesNoCallback
         this.buttonList.clear();
         
         // World name
-        this.txtWorldName = new GuiTextField(20, this.fontRendererObj, this.width / 2 - 164, 45 + heightOffset, 160, 20); //left, top, width, height           
+        this.txtWorldName = new GuiTextField(30, this.fontRendererObj, this.width / 2 - 164, 45, 160, 20); //left, top, width, height           
         this.txtWorldName.setText(GuiHandler.selectedWorldName != null ? GuiHandler.selectedWorldName : GuiHandler.worldName != null ? GuiHandler.worldName : I18n.format("selectWorld.newWorld", new Object[0]));
         this.txtWorldName.setEnabled(false);
         
         // Seed
-        this.txtSeed = new GuiTextField(21, this.fontRendererObj, this.width / 2 - 164, 101 + heightOffset, 160, 20);
+        this.txtSeed = new GuiTextField(31, this.fontRendererObj, this.width / 2 - 164, 101, 160, 20);
         this.txtSeed.setFocused(true);
         this.txtSeed.setText(GuiHandler.seed != null ? GuiHandler.seed : "");
 
         int btnwidth = 136;
         
         // Available worlds
-        btnavailableWorld1 = new GuiButton(3, this.width / 2 + 6, 43 + heightOffset, btnwidth, 20, "");            
-        btnavailableWorld2 = new GuiButton(4, this.width / 2 + 6, 43 + 24 + heightOffset, btnwidth, 20, "");
-        btnavailableWorld3 = new GuiButton(5, this.width / 2 + 6, 43 + 48 + heightOffset, btnwidth, 20, "");
-        btnavailableWorldPrev = new GuiButton(6, this.width / 2 + 6, 43 + 72 + heightOffset, 25, 20, "<");
-        btnavailableWorldNext = new GuiButton(7, this.width / 2 + 6 + 28, 43 + 72 + heightOffset, 25, 20, ">");
-        btnavailableWorldClone = new GuiButton(14, this.width / 2 + 6 + 56, 43 + 72 + heightOffset, 50, 20, "Clone");
+        btnavailableWorld1 = new GuiButton(3, this.width / 2 + 6, 43, btnwidth, 20, "");            
+        btnavailableWorld2 = new GuiButton(4, this.width / 2 + 6, 43 + 24, btnwidth, 20, "");
+        btnavailableWorld3 = new GuiButton(5, this.width / 2 + 6, 43 + 48, btnwidth, 20, "");
+        btnavailableWorldPrev = new GuiButton(6, this.width / 2 + 6, 43 + 72, 25, 20, "<");
+        btnavailableWorldNext = new GuiButton(7, this.width / 2 + 6 + 28, 43 + 72, 25, 20, ">");
+        btnavailableWorldClone = new GuiButton(14, this.width / 2 + 6 + 56, 43 + 72, 50, 20, "Clone");
     	btnavailableWorldClone.enabled = GuiHandler.selectedWorldName != null;
-        btnavailableWorldNew = new GuiButton(15, this.width / 2 + 6 + 110, 43 + 72 + heightOffset, 50, 20, "New");
+        btnavailableWorldNew = new GuiButton(15, this.width / 2 + 6 + 110, 43 + 72, 50, 20, "New");
         
         // Available worlds delete btns
-        btnavailableWorldDelete1 = new GuiButton(8, this.width / 2 + 6 + btnwidth + 4, 43 + heightOffset, 20, 20, "X");
-        btnavailableWorldDelete2 = new GuiButton(9, this.width / 2 + 6 + btnwidth + 4, 43 + 24 + heightOffset, 20, 20, "X");
-        btnavailableWorldDelete3 = new GuiButton(10, this.width / 2 + 6 + btnwidth + 4, 43 + 48 + heightOffset, 20, 20, "X");
+        btnavailableWorldDelete1 = new GuiButton(8, this.width / 2 + 6 + btnwidth + 4, 43, 20, 20, "X");
+        btnavailableWorldDelete2 = new GuiButton(9, this.width / 2 + 6 + btnwidth + 4, 43 + 24, 20, 20, "X");
+        btnavailableWorldDelete3 = new GuiButton(10, this.width / 2 + 6 + btnwidth + 4, 43 + 48, 20, 20, "X");
         
         this.buttonList.add(btnavailableWorld1);
         this.buttonList.add(btnavailableWorld2);
@@ -896,18 +917,26 @@ public class TCGuiCreateWorld extends GuiScreen implements GuiYesNoCallback
         
         FillAvailableWorlds();
                        
-        btnGameMode = new GuiButton(11, this.width / 2 - 166, 188 - heightOffset1 + heightOffset, 122, 20, I18n.format("selectWorld.gameMode", new Object[0]));
-        btnAllowCheats = new GuiButton(12, this.width / 2 - 39, 188 - heightOffset1 + heightOffset, 100, 20, I18n.format("selectWorld.allowCommands", new Object[0]));
-        btnBonusChest = new GuiButton(13, this.width / 2 + 66, 188 - heightOffset1 + heightOffset, 100, 20, I18n.format("selectWorld.bonusItems", new Object[0]));
+        // Pre-generation radius
+        this.txtPregenRadius = new GuiTextField(20, this.fontRendererObj, this.width / 2 - 164, 159, 50, 20);
+        this.txtPregenRadius.setText(((ForgeEngine)TerrainControl.getEngine()).getPregenerator().PregenerationRadius + "");
+                
+        // World border
+        this.txtWorldBorderRadius = new GuiTextField(21, this.fontRendererObj, this.width / 2 - 164 + 210, 159, 50, 20);
+        this.txtWorldBorderRadius.setText(((ForgeEngine)TerrainControl.getEngine()).WorldBorderRadius + "");
+        
+        btnGameMode = new GuiButton(11, this.width / 2 - 166, 188, 122, 20, I18n.format("selectWorld.gameMode", new Object[0]));
+        btnAllowCheats = new GuiButton(12, this.width / 2 - 39, 188, 100, 20, I18n.format("selectWorld.allowCommands", new Object[0]));
+        btnBonusChest = new GuiButton(13, this.width / 2 + 66, 188, 100, 20, I18n.format("selectWorld.bonusItems", new Object[0]));
         
         this.buttonList.add(btnGameMode);
         this.buttonList.add(btnAllowCheats);
         this.buttonList.add(btnBonusChest);
         
         // Create / Cancel
-        btnCreateWorld = new GuiButton(0, this.width / 2 - 166, 213 - heightOffset1 + heightOffset, 164, 20, I18n.format("selectWorld.create", new Object[0]));
+        btnCreateWorld = new GuiButton(0, this.width / 2 - 166, 213, 164, 20, I18n.format("selectWorld.create", new Object[0]));
         this.buttonList.add(btnCreateWorld);
-        this.buttonList.add(new GuiButton(1, this.width / 2 + 2, 213 - heightOffset1 + heightOffset, 164, 20, I18n.format("gui.cancel", new Object[0])));
+        this.buttonList.add(new GuiButton(1, this.width / 2 + 2, 213, 164, 20, I18n.format("gui.cancel", new Object[0])));
         
         this.updateWorldName();
         this.updateButtons();
@@ -921,20 +950,32 @@ public class TCGuiCreateWorld extends GuiScreen implements GuiYesNoCallback
         this.drawDefaultBackground();
         
         // Create new world title
-        this.drawCenteredString(this.fontRendererObj, I18n.format("Create a new TerrainControl world", new Object[0]), this.width / 2, 10 + heightOffset - heightOffset2, -1);
+        this.drawCenteredString(this.fontRendererObj, I18n.format("Create a new TerrainControl world", new Object[0]), this.width / 2, 10, -1);
 
         // World name
-        this.drawString(this.fontRendererObj, I18n.format("selectWorld.enterName", new Object[0]), this.width / 2 - 164, 30 + heightOffset, -6250336);
-        this.drawString(this.fontRendererObj, this.worldNameHelpText, this.width / 2 - 164, 70 + heightOffset, -6250336);
+        this.drawString(this.fontRendererObj, I18n.format("selectWorld.enterName", new Object[0]), this.width / 2 - 164, 30, -6250336);
+        this.drawString(this.fontRendererObj, this.worldNameHelpText, this.width / 2 - 164, 70, -6250336);
         this.txtWorldName.drawTextBox();
         
         // Available worlds
-        this.drawString(this.fontRendererObj, I18n.format("World settings", new Object[0]), this.width / 2 + 9, 30 + heightOffset, -6250336);
+        this.drawString(this.fontRendererObj, I18n.format("World settings", new Object[0]), this.width / 2 + 9, 30, -6250336);
         
         // Seed
-        this.drawString(this.fontRendererObj, I18n.format("selectWorld.enterSeed", new Object[0]), this.width / 2 - 164, 88 + heightOffset, -6250336);
-        this.drawString(this.fontRendererObj, I18n.format("selectWorld.seedInfo", new Object[0]), this.width / 2 - 164, 126 + heightOffset, -6250336);
+        this.drawString(this.fontRendererObj, I18n.format("selectWorld.enterSeed", new Object[0]), this.width / 2 - 164, 88, -6250336);
+        this.drawString(this.fontRendererObj, I18n.format("selectWorld.seedInfo", new Object[0]), this.width / 2 - 164, 126, -6250336);
         this.txtSeed.drawTextBox();
+        
+        // Pre-generation Radius 
+        this.drawString(this.fontRendererObj, "Pre-generation radius", this.width / 2 - 164, 145, -6250336);
+        
+        // World border Radius
+        this.drawString(this.fontRendererObj, "World border radius", this.width / 2 - 164 + 210, 145, -6250336);           
+        
+        this.drawString(this.fontRendererObj, "chunks", this.width / 2 - 164 + 60, 165, -6250336);
+        this.drawString(this.fontRendererObj, "chunks", this.width / 2 - 164 + 210 + 60, 165, -6250336);
+        
+        this.txtPregenRadius.drawTextBox();
+        this.txtWorldBorderRadius.drawTextBox();
 
         super.drawScreen(p_73863_1_, p_73863_2_, p_73863_3_);
     }

--- a/platforms/forge/src/main/java/com/khorn/terraincontrol/forge/gui/TCGuiWorldSelection.java
+++ b/platforms/forge/src/main/java/com/khorn/terraincontrol/forge/gui/TCGuiWorldSelection.java
@@ -2,36 +2,18 @@ package com.khorn.terraincontrol.forge.gui;
 
 import java.io.File;
 import java.io.IOException;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.Collections;
-import java.util.Date;
 
 import javax.annotation.Nullable;
 
-import net.minecraft.client.AnvilConverterException;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiCreateWorld;
-import net.minecraft.client.gui.GuiListWorldSelection;
-import net.minecraft.client.gui.GuiListWorldSelectionEntry;
 import net.minecraft.client.gui.GuiWorldSelection;
-import net.minecraft.client.gui.GuiErrorScreen;
 import net.minecraft.client.gui.GuiMainMenu;
 import net.minecraft.client.gui.GuiScreen;
-import net.minecraft.client.gui.GuiSlot;
-import net.minecraft.client.gui.GuiYesNo;
 import net.minecraft.client.gui.GuiYesNoCallback;
-import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.resources.I18n;
-import net.minecraft.world.WorldSettings;
-import net.minecraft.world.storage.ISaveFormat;
-import net.minecraft.world.storage.ISaveHandler;
-import net.minecraft.world.storage.WorldInfo;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import com.google.common.base.Splitter;
 import com.google.common.collect.Lists;
@@ -42,7 +24,6 @@ public class TCGuiWorldSelection extends GuiScreen implements GuiYesNoCallback
 {
 	// Taken from net.minecraft.client.gui.GuiWorldSelection. Changed confirmClicked and disabled rename button
 	
-    private static final Logger LOGGER = LogManager.getLogger();
     /** The screen to return to when this closes (always Main Menu). */
     protected GuiScreen prevScreen;
     protected String title = "Select world";
@@ -72,7 +53,6 @@ public class TCGuiWorldSelection extends GuiScreen implements GuiYesNoCallback
 		super.confirmClicked(ok, worldId);
 
 		// Check for world settings for this world
-		boolean bExists = false;
         File TCWorldsDirectory = new File(TerrainControl.getEngine().getTCDataFolder().getAbsolutePath() + "/worlds");
         if(TCWorldsDirectory.exists() && TCWorldsDirectory.isDirectory())
         {


### PR DESCRIPTION
- Added pre-generator with in-game UI, configurable via world creation
screen and WorldConfig
- Added world borders configurable in the world creation screen and
WorldConfig
- Added Cartographer world map, a miniature of the world that spawns at
spawn point and can be used to teleport around the world and explore
quickly. Also amusing during pre-generation!
-Added "Cartographer", "CartographerHeightOffset" and
"PregeneratorMaxChunksPerTick" settings to TerrainControl.ini
- Added "/tc cartographer", "/tc cartographer -tp", "/tc map" and "/tc
map -tp" console commands for use with the Cartographer world map
- Restricted console commands to TC worlds and dimensions and added
warnings
- Added some colors and spacing to console commands
- Fixed swamp colors (made them hardcoded for now)
- Fixed end and nether mob spawning and BiomeDict
- Fixed bug when writing branches to BO3's
- Added double-population warning to ObjectSpawner